### PR TITLE
fix: change order of openid auth metadata

### DIFF
--- a/.changeset/chilled-moons-confess.md
+++ b/.changeset/chilled-moons-confess.md
@@ -1,0 +1,5 @@
+---
+"@openid4vc/oauth2": minor
+---
+
+change order of fetching authorization server metadata. First `oauth-authorization-server` metadata is fetched now. If that returns a 404, the `openid-configuration` will be fetched.

--- a/.changeset/commit.js
+++ b/.changeset/commit.js
@@ -1,0 +1,24 @@
+const { execSync } = require('node:child_process')
+
+const getSignedOffBy = () => {
+  const gitUserName = execSync('git config user.name').toString('utf-8').trim()
+  const gitEmail = execSync('git config user.email').toString('utf-8').trim()
+
+  return `Signed-off-by: ${gitUserName} <${gitEmail}>`
+}
+
+const getAddMessage = async (changeset) => {
+  return `docs(changeset): ${changeset.summary}\n\n${getSignedOffBy()}\n`
+}
+
+const getVersionMessage = async (releasePlan) => {
+  const publishableReleases = releasePlan.releases.filter((release) => release.type !== 'none')
+  const releasedVersion = publishableReleases[0].newVersion
+
+  return `chore(release): version ${releasedVersion}\n\n${getSignedOffBy()}\n`
+}
+
+module.exports = {
+  getAddMessage,
+  getVersionMessage,
+}

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.1/schema.json",
   "changelog": "@changesets/cli/changelog",
+  "commit": "./commit",
   "privatePackages": false,
   "fixed": [["@openid4vc/*"]],
   "access": "public",


### PR DESCRIPTION
also adds a `commit.js` file to sign-off changeset commits

Signed-off-by: Timo Glastra <timo@animo.id>