### PR TITLE
feat: support v18-v24

### DIFF
--- a/packages/openid4vp/src/authorization-request/create-authorization-request.ts
+++ b/packages/openid4vp/src/authorization-request/create-authorization-request.ts
@@ -15,7 +15,7 @@ import {
 
 export interface CreateOpenid4vpAuthorizationRequestOptions {
   scheme?: string
-  requestParams: Openid4vpAuthorizationRequest | Openid4vpAuthorizationRequestDcApi
+  requestPayload: Openid4vpAuthorizationRequest | Openid4vpAuthorizationRequestDcApi
   jar?: {
     requestUri?: string
     jwtSigner: JwtSigner
@@ -43,15 +43,15 @@ export interface CreateOpenid4vpAuthorizationRequestOptions {
  * @returns Object containing the authorization request parameters, URI and optional JAR details
  */
 export async function createOpenid4vpAuthorizationRequest(options: CreateOpenid4vpAuthorizationRequestOptions) {
-  const { jar, scheme = 'openid4vp://', requestParams, wallet, callbacks } = options
+  const { jar, scheme = 'openid4vp://', requestPayload, wallet, callbacks } = options
 
   let additionalJwtPayload: Record<string, unknown> | undefined
 
   let authRequestParams: Openid4vpAuthorizationRequest | Openid4vpAuthorizationRequestDcApi
-  if (isOpenid4vpAuthorizationRequestDcApi(requestParams)) {
+  if (isOpenid4vpAuthorizationRequestDcApi(requestPayload)) {
     authRequestParams = parseWithErrorHandling(
       zOpenid4vpAuthorizationRequestDcApi,
-      requestParams,
+      requestPayload,
       'Invalid authorization request. Could not parse openid4vp dc_api authorization request.'
     )
 
@@ -69,7 +69,7 @@ export async function createOpenid4vpAuthorizationRequest(options: CreateOpenid4
   } else {
     authRequestParams = parseWithErrorHandling(
       zOpenid4vpAuthorizationRequest,
-      requestParams,
+      requestPayload,
       'Invalid authorization request. Could not parse openid4vp authorization request.'
     )
     validateOpenid4vpAuthorizationRequestPayload({ params: authRequestParams, walletVerificationOptions: wallet })
@@ -84,7 +84,7 @@ export async function createOpenid4vpAuthorizationRequest(options: CreateOpenid4
   if (jar) {
     const jarResult = await createJarAuthRequest({
       ...jar,
-      authRequestParams: requestParams,
+      authRequestParams: requestPayload,
       additionalJwtPayload,
       callbacks,
     })
@@ -105,11 +105,11 @@ export async function createOpenid4vpAuthorizationRequest(options: CreateOpenid4
   const url = new URL(scheme)
   url.search = `?${new URLSearchParams([
     ...url.searchParams.entries(),
-    ...objectToQueryParams(requestParams).entries(),
+    ...objectToQueryParams(requestPayload).entries(),
   ]).toString()}`
 
   return {
-    authRequestObject: requestParams,
+    authRequestObject: requestPayload,
     authRequest: url.toString(),
     jar: undefined,
   }

--- a/packages/openid4vp/src/authorization-request/z-authorization-request-dc-api.ts
+++ b/packages/openid4vp/src/authorization-request/z-authorization-request-dc-api.ts
@@ -16,7 +16,18 @@ export const zOpenid4vpAuthorizationRequestDcApi = zOpenid4vpAuthorizationReques
   .extend({
     client_id: z.optional(z.string()),
     expected_origins: z.array(z.string()).optional(),
-    response_mode: z.enum(['dc_api', 'dc_api.jwt']),
+    response_mode: z.enum(['dc_api', 'dc_api.jwt', 'w3c_dc_api.jwt', 'w3c_dc_api']),
+    client_id_scheme: z
+      .enum([
+        'pre-registered',
+        'redirect_uri',
+        'entity_id',
+        'did',
+        'verifier_attestation',
+        'x509_san_dns',
+        'x509_san_uri',
+      ])
+      .optional(),
   })
   .strip()
 
@@ -25,5 +36,10 @@ export type Openid4vpAuthorizationRequestDcApi = z.infer<typeof zOpenid4vpAuthor
 export function isOpenid4vpAuthorizationRequestDcApi(
   request: Openid4vpAuthorizationRequest | Openid4vpAuthorizationRequestDcApi | JarAuthRequest
 ): request is Openid4vpAuthorizationRequestDcApi {
-  return request.response_mode === 'dc_api' || request.response_mode === 'dc_api.jwt'
+  return (
+    request.response_mode === 'dc_api' ||
+    request.response_mode === 'dc_api.jwt' ||
+    request.response_mode === 'w3c_dc_api.jwt' ||
+    request.response_mode === 'w3c_dc_api'
+  )
 }

--- a/packages/openid4vp/src/authorization-request/z-authorization-request.ts
+++ b/packages/openid4vp/src/authorization-request/z-authorization-request.ts
@@ -18,9 +18,21 @@ export const zOpenid4vpAuthorizationRequest = z
     presentation_definition_uri: zHttpsUrl.optional(),
     dcql_query: z.record(z.any()).optional(),
     client_metadata: zClientMetadata.optional(),
+    client_metadata_uri: zHttpsUrl.optional(),
     state: z.string().optional(),
     transaction_data: z.array(z.string()).optional(),
     trust_chain: z.unknown().optional(),
+    client_id_scheme: z
+      .enum([
+        'pre-registered',
+        'redirect_uri',
+        'entity_id',
+        'did',
+        'verifier_attestation',
+        'x509_san_dns',
+        'x509_san_uri',
+      ])
+      .optional(),
   })
   .passthrough()
 

--- a/packages/openid4vp/src/authorization-response/parse-authorization-response.ts
+++ b/packages/openid4vp/src/authorization-response/parse-authorization-response.ts
@@ -31,8 +31,8 @@ export async function parseOpenid4vpAuthorizationResponse(options: ParseOpenid4v
   const authRequestPayload = parsedAuthRequest.params
 
   const validateOpenId4vpResponse = validateOpenid4vpAuthorizationResponse({
-    authorizationRequest: authRequestPayload,
-    authorizationResponse: authResponsePayload,
+    requestPayload: authRequestPayload,
+    responsePayload: authResponsePayload,
   })
 
   if (authRequestPayload.response_mode && isJarmResponseMode(authRequestPayload.response_mode)) {

--- a/packages/openid4vp/src/authorization-response/parse-jarm-authorization-response.ts
+++ b/packages/openid4vp/src/authorization-response/parse-jarm-authorization-response.ts
@@ -50,8 +50,8 @@ export async function parseJarmAuthorizationResponse(options: ParseJarmAuthoriza
 
   const authResponsePayload = parseOpenid4VpAuthorizationResponsePayload(verifiedJarmResponse.jarmAuthResponse)
   const validateOpenId4vpResponse = validateOpenid4vpAuthorizationResponse({
-    authorizationRequest: parsedAuthorizationRequest.params,
-    authorizationResponse: authResponsePayload,
+    requestPayload: parsedAuthorizationRequest.params,
+    responsePayload: authResponsePayload,
   })
 
   const authRequestPayload = parsedAuthorizationRequest.params

--- a/packages/openid4vp/src/authorization-response/submit-authorization-response.ts
+++ b/packages/openid4vp/src/authorization-response/submit-authorization-response.ts
@@ -6,19 +6,19 @@ import { jarmAuthResponseSend } from '../jarm/jarm-auth-response-send'
 import type { Openid4vpAuthorizationResponse } from './z-authorization-response'
 
 export interface SubmitOpenid4vpAuthorizationResponseOptions {
-  request: Pick<Openid4vpAuthorizationRequest, 'response_uri'>
-  response: Openid4vpAuthorizationResponse
+  requestPayload: Pick<Openid4vpAuthorizationRequest, 'response_uri'>
+  responsePayload: Openid4vpAuthorizationResponse
   jarm?: { responseJwt: string }
   callbacks: Pick<CallbackContext, 'fetch'>
 }
 
 export async function submitOpenid4vpAuthorizationResponse(options: SubmitOpenid4vpAuthorizationResponseOptions) {
-  const { request, response, jarm, callbacks } = options
-  const url = request.response_uri
+  const { requestPayload, responsePayload, jarm, callbacks } = options
+  const url = requestPayload.response_uri
 
   if (jarm) {
     return jarmAuthResponseSend({
-      authRequest: request,
+      authRequest: requestPayload,
       jarmAuthResponseJwt: jarm.responseJwt,
       callbacks,
     })
@@ -31,7 +31,7 @@ export async function submitOpenid4vpAuthorizationResponse(options: SubmitOpenid
   }
 
   const fetch = callbacks.fetch ?? defaultFetcher
-  const encodedResponse = objectToQueryParams(response)
+  const encodedResponse = objectToQueryParams(responsePayload)
   const submissionResponse = await fetch(url, {
     method: 'POST',
     body: encodedResponse,

--- a/packages/openid4vp/src/fetch-client-metadata.ts
+++ b/packages/openid4vp/src/fetch-client-metadata.ts
@@ -1,0 +1,35 @@
+import { Oauth2ErrorCodes, Oauth2ServerErrorResponseError } from '@openid4vc/oauth2'
+import { type BaseSchema, ContentType, type Fetch, createZodFetcher } from '@openid4vc/utils'
+import type { z } from 'zod'
+import { zWalletMetadata } from './models/z-wallet-metadata'
+
+export async function fetchClientMetadata<Schema extends BaseSchema>(options: {
+  clientMetadataUri: string
+  fetch?: Fetch
+}): Promise<z.infer<Schema> | null> {
+  const { fetch, clientMetadataUri } = options
+  const fetcher = createZodFetcher(fetch)
+
+  const { result, response } = await fetcher(zWalletMetadata, ContentType.Json, clientMetadataUri, {
+    method: 'GET',
+    headers: {
+      Accept: ContentType.Json,
+    },
+  })
+
+  if (!response.ok) {
+    throw new Oauth2ServerErrorResponseError({
+      error_description: `Fetching client metadata from '${clientMetadataUri}' failed with status code '${response.status}'.`,
+      error: Oauth2ErrorCodes.InvalidRequestUri,
+    })
+  }
+
+  if (!result || !result.success) {
+    throw new Oauth2ServerErrorResponseError({
+      error_description: `Parsing client metadata from '${clientMetadataUri}' failed.`,
+      error: Oauth2ErrorCodes.InvalidRequestObject,
+    })
+  }
+
+  return result.data
+}

--- a/packages/openid4vp/src/models/z-credential-formats.ts
+++ b/packages/openid4vp/src/models/z-credential-formats.ts
@@ -1,3 +1,3 @@
 import { z } from 'zod'
-export const zCredentialFormat = z.enum(['jwt_vc_json', 'ldp_vc', 'ac_vc', 'mso_mdoc', 'dc+sd-jwt'])
+export const zCredentialFormat = z.enum(['jwt_vc_json', 'ldp_vc', 'ac_vc', 'mso_mdoc', 'dc+sd-jwt', 'vc+sd-jwt'])
 export type CredentialFormat = z.infer<typeof zCredentialFormat>

--- a/packages/openid4vp/src/models/z-proof-formats.ts
+++ b/packages/openid4vp/src/models/z-proof-formats.ts
@@ -1,3 +1,3 @@
 import { z } from 'zod'
-export const zProofFormat = z.enum(['jwt_vp_json', 'ldc_vp', 'ac_vp', 'dc+sd-jwt', 'mso_mdoc'])
+export const zProofFormat = z.enum(['jwt_vp_json', 'ldc_vp', 'ac_vp', 'dc+sd-jwt', 'vc+sd-jwt', 'mso_mdoc'])
 export type ProofFormat = z.infer<typeof zProofFormat>

--- a/packages/openid4vp/src/version.ts
+++ b/packages/openid4vp/src/version.ts
@@ -5,7 +5,6 @@ import {
   isOpenid4vpAuthorizationRequestDcApi,
 } from './authorization-request/z-authorization-request-dc-api'
 import { zClientIdScheme } from './client-identifier-scheme/z-client-id-scheme'
-import type { CredentialFormat } from './models/z-credential-formats'
 
 export const Openid4vpVersion = [18, 19, 20, 21, 22, 23, 24] as const
 export type OpenId4VpVersion = (typeof Openid4vpVersion)[number]
@@ -18,28 +17,27 @@ export function parseAuthorizationRequestVersion(
   // 23
 
   const vp_formats = request.client_metadata?.vp_formats
-  if (vp_formats) {
-    if (Object.keys(vp_formats).includes('vc+sd-jwt' satisfies CredentialFormat)) {
-      requirements.push(['<', 23])
-    }
+  // There might be some time we'd like to include both, as the update of the identifier can be somewhat tricky.
+  //if (vp_formats) {
+  //if (Object.keys(vp_formats).includes('vc+sd-jwt' satisfies CredentialFormat)) {
+  //requirements.push(['<', 23])
+  //}
 
-    if (Object.keys(vp_formats).includes('dc+sd-jwt' satisfies CredentialFormat)) {
-      requirements.push(['>=', 23])
-    }
+  //if (Object.keys(vp_formats).includes('dc+sd-jwt' satisfies CredentialFormat)) {
+  //requirements.push(['>=', 23])
+  //}
 
+  //if (Object.keys(vp_formats).includes('vc+sd-jwt' satisfies CredentialFormat)) {
+  //requirements.push(['>=', 21])
+  //}
+  //}
 
-    if (Object.keys(vp_formats).includes('vc+sd-jwt' satisfies CredentialFormat)) {
-      requirements.push(['>=', 21])
-    }
-  }
-
-
-  if (
-    request.client_metadata?.vp_formats &&
-    Object.keys(request.client_metadata?.vp_formats).some(val => val === 'vc+sd-jwt')
-  ) {
-    requirements.push(['>=', 21])
-  }
+  //if (
+  //request.client_metadata?.vp_formats &&
+  //Object.keys(request.client_metadata?.vp_formats).some(val => val === 'vc+sd-jwt')
+  //) {
+  //requirements.push(['>=', 21])
+  //}
 
   if (
     isOpenid4vpAuthorizationRequestDcApi(request) &&

--- a/packages/openid4vp/src/version.ts
+++ b/packages/openid4vp/src/version.ts
@@ -1,0 +1,147 @@
+import { Oauth2ErrorCodes, Oauth2ServerErrorResponseError } from '@openid4vc/oauth2'
+import type { Openid4vpAuthorizationRequest } from './authorization-request/z-authorization-request'
+import {
+  type Openid4vpAuthorizationRequestDcApi,
+  isOpenid4vpAuthorizationRequestDcApi,
+} from './authorization-request/z-authorization-request-dc-api'
+import { zClientIdScheme } from './client-identifier-scheme/z-client-id-scheme'
+import type { CredentialFormat } from './models/z-credential-formats'
+
+export const Openid4vpVersion = [18, 19, 20, 21, 22, 23, 24] as const
+export type OpenId4VpVersion = (typeof Openid4vpVersion)[number]
+
+export function parseAuthorizationRequestVersion(
+  request: Openid4vpAuthorizationRequest | Openid4vpAuthorizationRequestDcApi
+): OpenId4VpVersion {
+  const requirements: ['<' | '>=', OpenId4VpVersion][] = []
+
+  // 23
+
+  const vp_formats = request.client_metadata?.vp_formats
+  if (vp_formats) {
+    if (Object.keys(vp_formats).includes('vc+sd-jwt' satisfies CredentialFormat)) {
+      requirements.push(['<', 23])
+    }
+
+    if (Object.keys(vp_formats).includes('dc+sd-jwt' satisfies CredentialFormat)) {
+      requirements.push(['>=', 23])
+    }
+
+
+    if (Object.keys(vp_formats).includes('vc+sd-jwt' satisfies CredentialFormat)) {
+      requirements.push(['>=', 21])
+    }
+  }
+
+
+  if (
+    request.client_metadata?.vp_formats &&
+    Object.keys(request.client_metadata?.vp_formats).some(val => val === 'vc+sd-jwt')
+  ) {
+    requirements.push(['>=', 21])
+  }
+
+  if (
+    isOpenid4vpAuthorizationRequestDcApi(request) &&
+    (request.response_mode === 'w3c_dc_api' || request.response_mode === 'w3c_dc_api.jwt')
+  ) {
+    requirements.push(['<', 23])
+    requirements.push(['>=', 21])
+  }
+
+  if (
+    (isOpenid4vpAuthorizationRequestDcApi(request) && request.response_mode === 'dc_api') ||
+    request.response_mode === 'dc_api.jwt'
+  ) {
+    requirements.push(['>=', 23])
+  }
+
+  if (isOpenid4vpAuthorizationRequestDcApi(request) && (request.transaction_data || request.dcql_query)) {
+    requirements.push(['>=', 23])
+  }
+
+  // 22
+
+  if (request.dcql_query) {
+    requirements.push(['>=', 22])
+  }
+
+  if (request.transaction_data) {
+    requirements.push(['>=', 22])
+  }
+
+  if (request.client_id_scheme) {
+    requirements.push(['<', 22])
+  }
+
+  // what happens if we don't have a client_id_scheme?
+
+  // if the client_id is prefixed with a scheme, we know for sure that the version is >= 22
+  // if it is not prefixed we don't know anything since it can default in all versions to pre-registered
+  if (request.client_id) {
+    const colonIndex = request.client_id.indexOf(':')
+    const schemePart = request.client_id.substring(0, colonIndex)
+    const parsedScheme = zClientIdScheme.safeParse(schemePart)
+
+    // we know this for sure
+    if (parsedScheme.success && parsedScheme.data !== 'did' && parsedScheme.data !== 'https') {
+      requirements.push(['>=', 22])
+    }
+  }
+
+  // only possible with dc_api which is available in 21
+  if (!request.client_id) {
+    requirements.push(['>=', 21])
+  }
+
+  // 21
+
+  if ('client_metadata_uri' in request) {
+    requirements.push(['<', 21])
+  }
+
+  if (isOpenid4vpAuthorizationRequestDcApi(request)) {
+    requirements.push(['>=', 21])
+  }
+
+  if ('request_uri_method' in request || 'wallet_nonce' in request) {
+    requirements.push(['>=', 21])
+  }
+
+  // 20
+
+  if (request.client_id_scheme === 'verifier_attestation') {
+    requirements.push(['>=', 20])
+  }
+
+  // 19
+
+  if (request.client_id_scheme === 'x509_san_dns' || request.client_id_scheme === 'x509_san_uri') {
+    requirements.push(['>=', 19])
+  }
+
+  // The minimum version which satisfies all requirements
+  const lessThanVersions = requirements.filter(([operator]) => operator === '<').map(([_, version]) => version)
+
+  const greaterThanVersions = requirements.filter(([operator]) => operator === '>=').map(([_, version]) => version)
+
+  // Find the minimum version that satisfies all "less than" constraints
+  const highestPossibleVersion =
+    lessThanVersions.length > 0 ? (Math.max(Math.min(...lessThanVersions) - 1, 18) as OpenId4VpVersion) : (24 as const) // Default to highest version
+
+  // Find the maximum version that satisfies all "greater than or equal to" constraints
+  const lowestRequiredVersion =
+    greaterThanVersions.length > 0 ? (Math.max(...greaterThanVersions) as OpenId4VpVersion) : (18 as const) // Default to lowest version
+
+  // The acceptable range is [lowestRequiredVersion, highestPossibleVersion]
+  // We return the lowest possible version that satisfies all constraints
+  if (lowestRequiredVersion > highestPossibleVersion) {
+    // No valid version exists that satisfies all constraints
+    throw new Oauth2ServerErrorResponseError({
+      error: Oauth2ErrorCodes.InvalidRequest,
+      error_description: 'Could not infer openid4vp version from the openid4vp request payload.',
+    })
+  }
+
+  return highestPossibleVersion
+}

--- a/packages/openid4vp/tests/full-flow.test.ts
+++ b/packages/openid4vp/tests/full-flow.test.ts
@@ -1,0 +1,199 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+import { getSignJwtCallback, callbacks as partialCallbacks } from '../../oauth2/tests/util'
+import {
+  createOpenid4vpAuthorizationResponse,
+  resolveOpenid4vpAuthorizationRequest,
+  submitOpenid4vpAuthorizationResponse,
+  validateOpenid4vpAuthorizationResponse,
+} from '../src'
+import { createOpenid4vpAuthorizationRequest } from '../src/authorization-request/create-authorization-request'
+import { parseOpenid4VpAuthorizationResponsePayload } from '../src/authorization-response/parse-authorization-response-payload'
+
+const exampleDcqlQuery = {
+  credentials: [
+    {
+      id: 'orgeuuniversity',
+      format: 'mso_mdoc',
+      meta: { doctype_value: 'org.eu.university' },
+      claims: [
+        { namespace: 'eu.europa.ec.eudi.pid.1', claim_name: 'name' },
+        { namespace: 'eu.europa.ec.eudi.pid.1', claim_name: 'degree' },
+        { namespace: 'eu.europa.ec.eudi.pid.1', claim_name: 'date' },
+      ],
+    },
+    {
+      id: 'OpenBadgeCredentialDescriptor',
+      format: 'dc+sd-jwt',
+      meta: { vct_values: ['OpenBadgeCredential'] },
+      claims: [{ path: ['university'] }],
+    },
+  ],
+}
+
+const exampleVptoken = {
+  orgeuuniversity:
+    'uQADZ3ZlcnNpb25jMS4waWRvY3VtZW50c4GjZ2RvY1R5cGVxb3JnLmV1LnVuaXZlcnNpdHlsaXNzdWVyU2lnbmVkuQACam5hbWVTcGFjZXOhd2V1LmV1cm9wYS5lYy5ldWRpLnBpZC4xg9gYWGGkaGRpZ2VzdElEA3FlbGVtZW50SWRlbnRpZmllcmRuYW1lbGVsZW1lbnRWYWx1ZWhKb2huIERvZWZyYW5kb21YIEWyJGCZTVxZPQlUipZgJrFHAG953ShscUxOhqcVj5zZ2BhYY6RoZGlnZXN0SUQBcWVsZW1lbnRJZGVudGlmaWVyZmRlZ3JlZWxlbGVtZW50VmFsdWVoYmFjaGVsb3JmcmFuZG9tWCAK5tJW8iDu2_pFMZbncXHsVSoMPB-j6NHzTidrmAwglNgYWGakaGRpZ2VzdElEAnFlbGVtZW50SWRlbnRpZmllcmRkYXRlbGVsZW1lbnRWYWx1ZdkD7GoyMDI1LTAyLTI3ZnJhbmRvbVggHkxQ5P0ym4b-S2YhPULns-6950O_pu1f01YH4KZf7RFqaXNzdWVyQXV0aIRDoQEmogRYMXpEbmFlYVpVV3dVUmpyNVE1TTJnMnVjZjE2bjNwVUx4bzRDaHFuZktYTnJNMk53MUsYIYFZAR4wggEaMIHAoAMCAQICEBe3X5XsrOs2ZhTfjDA0whkwCgYIKoZIzj0EAwIwDTELMAkGA1UEAxMCREUwHhcNMjUwMjI3MDkxOTMzWhcNMjYwMjI3MDkxOTMzWjANMQswCQYDVQQDEwJERTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJaBQfh-jpNhVxqwlTlv39Gm3nkewRvcA4p9TRao8YlC271XGo2ojTBcNh-RX65ql--tNygiJh6BHNhz98VPcVCjAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCx9YNNPzp7YPPdy4k3IVR_XLl6e7bnKS91cGEwArbMzgIhAIuglfUtfZM-ZYoEX1xYB47wMm666Trcykjag1sYMfgZWQIA2BhZAfu5AAZndmVyc2lvbmMxLjBvZGlnZXN0QWxnb3JpdGhtZ1NIQS0yNTZsdmFsdWVEaWdlc3RzoXdldS5ldXJvcGEuZWMuZXVkaS5waWQuMaUAWCAVPsuROLqNqsVsaaCrTJzdHdZ_IznS1nCh1qVKWZ2ezQFYIPeazaLvXv5M-s2h9713AG_QJcCZW-eu6UGzoGI6O9ZnAlggqnuFzR9wHj_51ftmjpqo5s-XIvjoLPw-5sfQ-IGtp1kDWCByQ8dnllyBLPNL1DgHqA0B8yAuvY-EoCVGmEAWMAbeowRYICrRJfwVhE9JJzLpa6tfc1LJ9rvv0sr2OzQ9ot-68CnNbWRldmljZUtleUluZm-5AAFpZGV2aWNlS2V5pAECIAEhWCAakKubHmMGh9_OHyUGEZ8102VOMM6j7C-MlEyHDyYJ1yJYIJbQibZhVZZ2ghRAClhsQO_fXpWcqRQKhriSZ4azbE2oZ2RvY1R5cGVxb3JnLmV1LnVuaXZlcnNpdHlsdmFsaWRpdHlJbmZvuQAEZnNpZ25lZMB0MjAyNS0wMi0yN1QwOToxOTozM1ppdmFsaWRGcm9twHQyMDI1LTAyLTI3VDA5OjE5OjMzWmp2YWxpZFVudGlswHQyMDI2LTAyLTI3VDA5OjE5OjMzWm5leHBlY3RlZFVwZGF0ZfdYQCFznxzCxRUqSe65YB3p1pjTEK7Sma4-JTUhnbwsdmtAoLBv5NMlu54mHj7oGCRBmN3G_un8GeX2opmG78yVdJNsZGV2aWNlU2lnbmVkuQACam5hbWVTcGFjZXPYGEGgamRldmljZUF1dGi5AAJvZGV2aWNlU2lnbmF0dXJlhEOhASag9lhA0kcpmpDK-lGZnNZ_cCjb_CbEz6UZ_MwymXE9r1j9YFrSpoahLj6dkprCZuaS1K79dvSZQTHw23KHzP_JAGFcj2lkZXZpY2VNYWP3ZnN0YXR1cwA',
+  OpenBadgeCredentialDescriptor:
+    'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSIsImtpZCI6IiN6Nk1rcnpRUEJyNHB5cUM3NzZLS3RyejEzU2NoTTVlUFBic3N1UHVRWmI1dDR1S1EifQ.eyJ2Y3QiOiJPcGVuQmFkZ2VDcmVkZW50aWFsIiwiZGVncmVlIjoiYmFjaGVsb3IiLCJjbmYiOnsia2lkIjoiZGlkOmtleTp6Nk1rcEdSNGdzNFJjM1pwaDR2ajh3Um5qbkF4Z0FQU3hjUjhNQVZLdXRXc3BRemMjejZNa3BHUjRnczRSYzNacGg0dmo4d1Juam5BeGdBUFN4Y1I4TUFWS3V0V3NwUXpjIn0sImlzcyI6ImRpZDprZXk6ejZNa3J6UVBCcjRweXFDNzc2S0t0cnoxM1NjaE01ZVBQYnNzdVB1UVpiNXQ0dUtRIiwiaWF0IjoxNzQwNjQ3OTczLCJfc2QiOlsiSEtyNW1mYkE2OGRZY0JYZTVMRDREdFJHdjVoNWp0NEVDT2JSOWF5VkJCOCIsImlBYS1YVXhGaG1nU0g2SWhTOHZ2cm1TWF95VHJ2ZTQtZjFjTWRPLU41VUUiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.pP2G3YxexmDGpF-vfb04zMhVLLJGjkiVUiA-I-aLVdhNqzCjexOAu9xQOt0uTGT-4_ly_j66FXR2v4p0z9iyBw~WyI2NTgyNDY2MzM4MjYyODgyMjY2Nzc2MTkiLCJ1bml2ZXJzaXR5IiwiaW5uc2JydWNrIl0~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE3NDA2NDc5NzYsIm5vbmNlIjoiNDczODIzNzM5Nzg4MzU1NzEyMTc3MzUwIiwiYXVkIjoieDUwOV9zYW5fZG5zOmxvY2FsaG9zdDoxMjM0IiwidHJhbnNhY3Rpb25fZGF0YV9oYXNoZXMiOlsiWHd5VmQ3d0ZSRWRWV0xwbmk1UU5IZ2dOV1hvMko0TG41OHQyX2VjSjczcyJdLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOiJzaGEtMjU2Iiwic2RfaGFzaCI6IkJFQ09xRm9OMjM0UldtRzEtTUlSWXl5SnpXTDg1XzRLdTdHNC1KcUl4V0UifQ.ZnDZBS8o_WPsTlvuUO0SnARUIvx1M8t9Fd6TiaQbMtT_0OA7QCvdpisSh9-NfLAb40frAED875W8RI3zi06-DQ',
+}
+
+const server = setupServer()
+
+const callbacks = {
+  ...partialCallbacks,
+  fetch,
+  signJwt: getSignJwtCallback([]),
+  encryptJwe: () => {
+    throw new Error('Not implemented')
+  },
+  decryptJwe: () => {
+    throw new Error('Not implemented')
+  },
+}
+
+describe('Full E2E openid4vp test', () => {
+  beforeAll(() => {
+    server.listen()
+  })
+
+  afterEach(() => {
+    server.resetHandlers()
+  })
+
+  afterAll(() => {
+    server.close()
+  })
+
+  test('openid4vp (unsigned)', async () => {
+    callbacks.fetch = fetch
+    const requestPayload = {
+      nonce: 'nonce',
+      client_metadata: {},
+      response_mode: 'direct_post',
+      dcql_query: exampleDcqlQuery,
+      response_uri: 'https://example.com/response_uri',
+      response_type: 'vp_token',
+      client_id: 'client_id',
+    } as const
+
+    server.resetHandlers(
+      http.post(requestPayload.response_uri, async ({ request }) => {
+        try {
+          const formData = await request.formData()
+          const rawResponsePayload = Object.fromEntries(formData.entries())
+          expect(rawResponsePayload).toMatchObject({
+            vp_token:
+              '{"orgeuuniversity":"uQADZ3ZlcnNpb25jMS4waWRvY3VtZW50c4GjZ2RvY1R5cGVxb3JnLmV1LnVuaXZlcnNpdHlsaXNzdWVyU2lnbmVkuQACam5hbWVTcGFjZXOhd2V1LmV1cm9wYS5lYy5ldWRpLnBpZC4xg9gYWGGkaGRpZ2VzdElEA3FlbGVtZW50SWRlbnRpZmllcmRuYW1lbGVsZW1lbnRWYWx1ZWhKb2huIERvZWZyYW5kb21YIEWyJGCZTVxZPQlUipZgJrFHAG953ShscUxOhqcVj5zZ2BhYY6RoZGlnZXN0SUQBcWVsZW1lbnRJZGVudGlmaWVyZmRlZ3JlZWxlbGVtZW50VmFsdWVoYmFjaGVsb3JmcmFuZG9tWCAK5tJW8iDu2_pFMZbncXHsVSoMPB-j6NHzTidrmAwglNgYWGakaGRpZ2VzdElEAnFlbGVtZW50SWRlbnRpZmllcmRkYXRlbGVsZW1lbnRWYWx1ZdkD7GoyMDI1LTAyLTI3ZnJhbmRvbVggHkxQ5P0ym4b-S2YhPULns-6950O_pu1f01YH4KZf7RFqaXNzdWVyQXV0aIRDoQEmogRYMXpEbmFlYVpVV3dVUmpyNVE1TTJnMnVjZjE2bjNwVUx4bzRDaHFuZktYTnJNMk53MUsYIYFZAR4wggEaMIHAoAMCAQICEBe3X5XsrOs2ZhTfjDA0whkwCgYIKoZIzj0EAwIwDTELMAkGA1UEAxMCREUwHhcNMjUwMjI3MDkxOTMzWhcNMjYwMjI3MDkxOTMzWjANMQswCQYDVQQDEwJERTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJaBQfh-jpNhVxqwlTlv39Gm3nkewRvcA4p9TRao8YlC271XGo2ojTBcNh-RX65ql--tNygiJh6BHNhz98VPcVCjAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCx9YNNPzp7YPPdy4k3IVR_XLl6e7bnKS91cGEwArbMzgIhAIuglfUtfZM-ZYoEX1xYB47wMm666Trcykjag1sYMfgZWQIA2BhZAfu5AAZndmVyc2lvbmMxLjBvZGlnZXN0QWxnb3JpdGhtZ1NIQS0yNTZsdmFsdWVEaWdlc3RzoXdldS5ldXJvcGEuZWMuZXVkaS5waWQuMaUAWCAVPsuROLqNqsVsaaCrTJzdHdZ_IznS1nCh1qVKWZ2ezQFYIPeazaLvXv5M-s2h9713AG_QJcCZW-eu6UGzoGI6O9ZnAlggqnuFzR9wHj_51ftmjpqo5s-XIvjoLPw-5sfQ-IGtp1kDWCByQ8dnllyBLPNL1DgHqA0B8yAuvY-EoCVGmEAWMAbeowRYICrRJfwVhE9JJzLpa6tfc1LJ9rvv0sr2OzQ9ot-68CnNbWRldmljZUtleUluZm-5AAFpZGV2aWNlS2V5pAECIAEhWCAakKubHmMGh9_OHyUGEZ8102VOMM6j7C-MlEyHDyYJ1yJYIJbQibZhVZZ2ghRAClhsQO_fXpWcqRQKhriSZ4azbE2oZ2RvY1R5cGVxb3JnLmV1LnVuaXZlcnNpdHlsdmFsaWRpdHlJbmZvuQAEZnNpZ25lZMB0MjAyNS0wMi0yN1QwOToxOTozM1ppdmFsaWRGcm9twHQyMDI1LTAyLTI3VDA5OjE5OjMzWmp2YWxpZFVudGlswHQyMDI2LTAyLTI3VDA5OjE5OjMzWm5leHBlY3RlZFVwZGF0ZfdYQCFznxzCxRUqSe65YB3p1pjTEK7Sma4-JTUhnbwsdmtAoLBv5NMlu54mHj7oGCRBmN3G_un8GeX2opmG78yVdJNsZGV2aWNlU2lnbmVkuQACam5hbWVTcGFjZXPYGEGgamRldmljZUF1dGi5AAJvZGV2aWNlU2lnbmF0dXJlhEOhASag9lhA0kcpmpDK-lGZnNZ_cCjb_CbEz6UZ_MwymXE9r1j9YFrSpoahLj6dkprCZuaS1K79dvSZQTHw23KHzP_JAGFcj2lkZXZpY2VNYWP3ZnN0YXR1cwA","OpenBadgeCredentialDescriptor":"eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSIsImtpZCI6IiN6Nk1rcnpRUEJyNHB5cUM3NzZLS3RyejEzU2NoTTVlUFBic3N1UHVRWmI1dDR1S1EifQ.eyJ2Y3QiOiJPcGVuQmFkZ2VDcmVkZW50aWFsIiwiZGVncmVlIjoiYmFjaGVsb3IiLCJjbmYiOnsia2lkIjoiZGlkOmtleTp6Nk1rcEdSNGdzNFJjM1pwaDR2ajh3Um5qbkF4Z0FQU3hjUjhNQVZLdXRXc3BRemMjejZNa3BHUjRnczRSYzNacGg0dmo4d1Juam5BeGdBUFN4Y1I4TUFWS3V0V3NwUXpjIn0sImlzcyI6ImRpZDprZXk6ejZNa3J6UVBCcjRweXFDNzc2S0t0cnoxM1NjaE01ZVBQYnNzdVB1UVpiNXQ0dUtRIiwiaWF0IjoxNzQwNjQ3OTczLCJfc2QiOlsiSEtyNW1mYkE2OGRZY0JYZTVMRDREdFJHdjVoNWp0NEVDT2JSOWF5VkJCOCIsImlBYS1YVXhGaG1nU0g2SWhTOHZ2cm1TWF95VHJ2ZTQtZjFjTWRPLU41VUUiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.pP2G3YxexmDGpF-vfb04zMhVLLJGjkiVUiA-I-aLVdhNqzCjexOAu9xQOt0uTGT-4_ly_j66FXR2v4p0z9iyBw~WyI2NTgyNDY2MzM4MjYyODgyMjY2Nzc2MTkiLCJ1bml2ZXJzaXR5IiwiaW5uc2JydWNrIl0~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE3NDA2NDc5NzYsIm5vbmNlIjoiNDczODIzNzM5Nzg4MzU1NzEyMTc3MzUwIiwiYXVkIjoieDUwOV9zYW5fZG5zOmxvY2FsaG9zdDoxMjM0IiwidHJhbnNhY3Rpb25fZGF0YV9oYXNoZXMiOlsiWHd5VmQ3d0ZSRWRWV0xwbmk1UU5IZ2dOV1hvMko0TG41OHQyX2VjSjczcyJdLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOiJzaGEtMjU2Iiwic2RfaGFzaCI6IkJFQ09xRm9OMjM0UldtRzEtTUlSWXl5SnpXTDg1XzRLdTdHNC1KcUl4V0UifQ.ZnDZBS8o_WPsTlvuUO0SnARUIvx1M8t9Fd6TiaQbMtT_0OA7QCvdpisSh9-NfLAb40frAED875W8RI3zi06-DQ"}',
+          })
+
+          const parsedResponse = parseOpenid4VpAuthorizationResponsePayload(rawResponsePayload)
+          expect(parsedResponse).toMatchObject({
+            vp_token:
+              '{"orgeuuniversity":"uQADZ3ZlcnNpb25jMS4waWRvY3VtZW50c4GjZ2RvY1R5cGVxb3JnLmV1LnVuaXZlcnNpdHlsaXNzdWVyU2lnbmVkuQACam5hbWVTcGFjZXOhd2V1LmV1cm9wYS5lYy5ldWRpLnBpZC4xg9gYWGGkaGRpZ2VzdElEA3FlbGVtZW50SWRlbnRpZmllcmRuYW1lbGVsZW1lbnRWYWx1ZWhKb2huIERvZWZyYW5kb21YIEWyJGCZTVxZPQlUipZgJrFHAG953ShscUxOhqcVj5zZ2BhYY6RoZGlnZXN0SUQBcWVsZW1lbnRJZGVudGlmaWVyZmRlZ3JlZWxlbGVtZW50VmFsdWVoYmFjaGVsb3JmcmFuZG9tWCAK5tJW8iDu2_pFMZbncXHsVSoMPB-j6NHzTidrmAwglNgYWGakaGRpZ2VzdElEAnFlbGVtZW50SWRlbnRpZmllcmRkYXRlbGVsZW1lbnRWYWx1ZdkD7GoyMDI1LTAyLTI3ZnJhbmRvbVggHkxQ5P0ym4b-S2YhPULns-6950O_pu1f01YH4KZf7RFqaXNzdWVyQXV0aIRDoQEmogRYMXpEbmFlYVpVV3dVUmpyNVE1TTJnMnVjZjE2bjNwVUx4bzRDaHFuZktYTnJNMk53MUsYIYFZAR4wggEaMIHAoAMCAQICEBe3X5XsrOs2ZhTfjDA0whkwCgYIKoZIzj0EAwIwDTELMAkGA1UEAxMCREUwHhcNMjUwMjI3MDkxOTMzWhcNMjYwMjI3MDkxOTMzWjANMQswCQYDVQQDEwJERTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJaBQfh-jpNhVxqwlTlv39Gm3nkewRvcA4p9TRao8YlC271XGo2ojTBcNh-RX65ql--tNygiJh6BHNhz98VPcVCjAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCx9YNNPzp7YPPdy4k3IVR_XLl6e7bnKS91cGEwArbMzgIhAIuglfUtfZM-ZYoEX1xYB47wMm666Trcykjag1sYMfgZWQIA2BhZAfu5AAZndmVyc2lvbmMxLjBvZGlnZXN0QWxnb3JpdGhtZ1NIQS0yNTZsdmFsdWVEaWdlc3RzoXdldS5ldXJvcGEuZWMuZXVkaS5waWQuMaUAWCAVPsuROLqNqsVsaaCrTJzdHdZ_IznS1nCh1qVKWZ2ezQFYIPeazaLvXv5M-s2h9713AG_QJcCZW-eu6UGzoGI6O9ZnAlggqnuFzR9wHj_51ftmjpqo5s-XIvjoLPw-5sfQ-IGtp1kDWCByQ8dnllyBLPNL1DgHqA0B8yAuvY-EoCVGmEAWMAbeowRYICrRJfwVhE9JJzLpa6tfc1LJ9rvv0sr2OzQ9ot-68CnNbWRldmljZUtleUluZm-5AAFpZGV2aWNlS2V5pAECIAEhWCAakKubHmMGh9_OHyUGEZ8102VOMM6j7C-MlEyHDyYJ1yJYIJbQibZhVZZ2ghRAClhsQO_fXpWcqRQKhriSZ4azbE2oZ2RvY1R5cGVxb3JnLmV1LnVuaXZlcnNpdHlsdmFsaWRpdHlJbmZvuQAEZnNpZ25lZMB0MjAyNS0wMi0yN1QwOToxOTozM1ppdmFsaWRGcm9twHQyMDI1LTAyLTI3VDA5OjE5OjMzWmp2YWxpZFVudGlswHQyMDI2LTAyLTI3VDA5OjE5OjMzWm5leHBlY3RlZFVwZGF0ZfdYQCFznxzCxRUqSe65YB3p1pjTEK7Sma4-JTUhnbwsdmtAoLBv5NMlu54mHj7oGCRBmN3G_un8GeX2opmG78yVdJNsZGV2aWNlU2lnbmVkuQACam5hbWVTcGFjZXPYGEGgamRldmljZUF1dGi5AAJvZGV2aWNlU2lnbmF0dXJlhEOhASag9lhA0kcpmpDK-lGZnNZ_cCjb_CbEz6UZ_MwymXE9r1j9YFrSpoahLj6dkprCZuaS1K79dvSZQTHw23KHzP_JAGFcj2lkZXZpY2VNYWP3ZnN0YXR1cwA","OpenBadgeCredentialDescriptor":"eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSIsImtpZCI6IiN6Nk1rcnpRUEJyNHB5cUM3NzZLS3RyejEzU2NoTTVlUFBic3N1UHVRWmI1dDR1S1EifQ.eyJ2Y3QiOiJPcGVuQmFkZ2VDcmVkZW50aWFsIiwiZGVncmVlIjoiYmFjaGVsb3IiLCJjbmYiOnsia2lkIjoiZGlkOmtleTp6Nk1rcEdSNGdzNFJjM1pwaDR2ajh3Um5qbkF4Z0FQU3hjUjhNQVZLdXRXc3BRemMjejZNa3BHUjRnczRSYzNacGg0dmo4d1Juam5BeGdBUFN4Y1I4TUFWS3V0V3NwUXpjIn0sImlzcyI6ImRpZDprZXk6ejZNa3J6UVBCcjRweXFDNzc2S0t0cnoxM1NjaE01ZVBQYnNzdVB1UVpiNXQ0dUtRIiwiaWF0IjoxNzQwNjQ3OTczLCJfc2QiOlsiSEtyNW1mYkE2OGRZY0JYZTVMRDREdFJHdjVoNWp0NEVDT2JSOWF5VkJCOCIsImlBYS1YVXhGaG1nU0g2SWhTOHZ2cm1TWF95VHJ2ZTQtZjFjTWRPLU41VUUiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.pP2G3YxexmDGpF-vfb04zMhVLLJGjkiVUiA-I-aLVdhNqzCjexOAu9xQOt0uTGT-4_ly_j66FXR2v4p0z9iyBw~WyI2NTgyNDY2MzM4MjYyODgyMjY2Nzc2MTkiLCJ1bml2ZXJzaXR5IiwiaW5uc2JydWNrIl0~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE3NDA2NDc5NzYsIm5vbmNlIjoiNDczODIzNzM5Nzg4MzU1NzEyMTc3MzUwIiwiYXVkIjoieDUwOV9zYW5fZG5zOmxvY2FsaG9zdDoxMjM0IiwidHJhbnNhY3Rpb25fZGF0YV9oYXNoZXMiOlsiWHd5VmQ3d0ZSRWRWV0xwbmk1UU5IZ2dOV1hvMko0TG41OHQyX2VjSjczcyJdLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOiJzaGEtMjU2Iiwic2RfaGFzaCI6IkJFQ09xRm9OMjM0UldtRzEtTUlSWXl5SnpXTDg1XzRLdTdHNC1KcUl4V0UifQ.ZnDZBS8o_WPsTlvuUO0SnARUIvx1M8t9Fd6TiaQbMtT_0OA7QCvdpisSh9-NfLAb40frAED875W8RI3zi06-DQ"}',
+          })
+
+          const validatedResult = validateOpenid4vpAuthorizationResponse({
+            requestPayload: requestPayload,
+            responsePayload: parsedResponse,
+          })
+
+          expect(validatedResult).toMatchObject({
+            type: 'dcql',
+            dcql: {
+              query: exampleDcqlQuery,
+              presentation: {
+                orgeuuniversity: {
+                  format: 'mso_mdoc',
+                  presentation:
+                    'uQADZ3ZlcnNpb25jMS4waWRvY3VtZW50c4GjZ2RvY1R5cGVxb3JnLmV1LnVuaXZlcnNpdHlsaXNzdWVyU2lnbmVkuQACam5hbWVTcGFjZXOhd2V1LmV1cm9wYS5lYy5ldWRpLnBpZC4xg9gYWGGkaGRpZ2VzdElEA3FlbGVtZW50SWRlbnRpZmllcmRuYW1lbGVsZW1lbnRWYWx1ZWhKb2huIERvZWZyYW5kb21YIEWyJGCZTVxZPQlUipZgJrFHAG953ShscUxOhqcVj5zZ2BhYY6RoZGlnZXN0SUQBcWVsZW1lbnRJZGVudGlmaWVyZmRlZ3JlZWxlbGVtZW50VmFsdWVoYmFjaGVsb3JmcmFuZG9tWCAK5tJW8iDu2_pFMZbncXHsVSoMPB-j6NHzTidrmAwglNgYWGakaGRpZ2VzdElEAnFlbGVtZW50SWRlbnRpZmllcmRkYXRlbGVsZW1lbnRWYWx1ZdkD7GoyMDI1LTAyLTI3ZnJhbmRvbVggHkxQ5P0ym4b-S2YhPULns-6950O_pu1f01YH4KZf7RFqaXNzdWVyQXV0aIRDoQEmogRYMXpEbmFlYVpVV3dVUmpyNVE1TTJnMnVjZjE2bjNwVUx4bzRDaHFuZktYTnJNMk53MUsYIYFZAR4wggEaMIHAoAMCAQICEBe3X5XsrOs2ZhTfjDA0whkwCgYIKoZIzj0EAwIwDTELMAkGA1UEAxMCREUwHhcNMjUwMjI3MDkxOTMzWhcNMjYwMjI3MDkxOTMzWjANMQswCQYDVQQDEwJERTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJaBQfh-jpNhVxqwlTlv39Gm3nkewRvcA4p9TRao8YlC271XGo2ojTBcNh-RX65ql--tNygiJh6BHNhz98VPcVCjAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCx9YNNPzp7YPPdy4k3IVR_XLl6e7bnKS91cGEwArbMzgIhAIuglfUtfZM-ZYoEX1xYB47wMm666Trcykjag1sYMfgZWQIA2BhZAfu5AAZndmVyc2lvbmMxLjBvZGlnZXN0QWxnb3JpdGhtZ1NIQS0yNTZsdmFsdWVEaWdlc3RzoXdldS5ldXJvcGEuZWMuZXVkaS5waWQuMaUAWCAVPsuROLqNqsVsaaCrTJzdHdZ_IznS1nCh1qVKWZ2ezQFYIPeazaLvXv5M-s2h9713AG_QJcCZW-eu6UGzoGI6O9ZnAlggqnuFzR9wHj_51ftmjpqo5s-XIvjoLPw-5sfQ-IGtp1kDWCByQ8dnllyBLPNL1DgHqA0B8yAuvY-EoCVGmEAWMAbeowRYICrRJfwVhE9JJzLpa6tfc1LJ9rvv0sr2OzQ9ot-68CnNbWRldmljZUtleUluZm-5AAFpZGV2aWNlS2V5pAECIAEhWCAakKubHmMGh9_OHyUGEZ8102VOMM6j7C-MlEyHDyYJ1yJYIJbQibZhVZZ2ghRAClhsQO_fXpWcqRQKhriSZ4azbE2oZ2RvY1R5cGVxb3JnLmV1LnVuaXZlcnNpdHlsdmFsaWRpdHlJbmZvuQAEZnNpZ25lZMB0MjAyNS0wMi0yN1QwOToxOTozM1ppdmFsaWRGcm9twHQyMDI1LTAyLTI3VDA5OjE5OjMzWmp2YWxpZFVudGlswHQyMDI2LTAyLTI3VDA5OjE5OjMzWm5leHBlY3RlZFVwZGF0ZfdYQCFznxzCxRUqSe65YB3p1pjTEK7Sma4-JTUhnbwsdmtAoLBv5NMlu54mHj7oGCRBmN3G_un8GeX2opmG78yVdJNsZGV2aWNlU2lnbmVkuQACam5hbWVTcGFjZXPYGEGgamRldmljZUF1dGi5AAJvZGV2aWNlU2lnbmF0dXJlhEOhASag9lhA0kcpmpDK-lGZnNZ_cCjb_CbEz6UZ_MwymXE9r1j9YFrSpoahLj6dkprCZuaS1K79dvSZQTHw23KHzP_JAGFcj2lkZXZpY2VNYWP3ZnN0YXR1cwA',
+                  path: undefined,
+                },
+                OpenBadgeCredentialDescriptor: {
+                  format: 'dc+sd-jwt',
+                  presentation:
+                    'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSIsImtpZCI6IiN6Nk1rcnpRUEJyNHB5cUM3NzZLS3RyejEzU2NoTTVlUFBic3N1UHVRWmI1dDR1S1EifQ.eyJ2Y3QiOiJPcGVuQmFkZ2VDcmVkZW50aWFsIiwiZGVncmVlIjoiYmFjaGVsb3IiLCJjbmYiOnsia2lkIjoiZGlkOmtleTp6Nk1rcEdSNGdzNFJjM1pwaDR2ajh3Um5qbkF4Z0FQU3hjUjhNQVZLdXRXc3BRemMjejZNa3BHUjRnczRSYzNacGg0dmo4d1Juam5BeGdBUFN4Y1I4TUFWS3V0V3NwUXpjIn0sImlzcyI6ImRpZDprZXk6ejZNa3J6UVBCcjRweXFDNzc2S0t0cnoxM1NjaE01ZVBQYnNzdVB1UVpiNXQ0dUtRIiwiaWF0IjoxNzQwNjQ3OTczLCJfc2QiOlsiSEtyNW1mYkE2OGRZY0JYZTVMRDREdFJHdjVoNWp0NEVDT2JSOWF5VkJCOCIsImlBYS1YVXhGaG1nU0g2SWhTOHZ2cm1TWF95VHJ2ZTQtZjFjTWRPLU41VUUiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.pP2G3YxexmDGpF-vfb04zMhVLLJGjkiVUiA-I-aLVdhNqzCjexOAu9xQOt0uTGT-4_ly_j66FXR2v4p0z9iyBw~WyI2NTgyNDY2MzM4MjYyODgyMjY2Nzc2MTkiLCJ1bml2ZXJzaXR5IiwiaW5uc2JydWNrIl0~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE3NDA2NDc5NzYsIm5vbmNlIjoiNDczODIzNzM5Nzg4MzU1NzEyMTc3MzUwIiwiYXVkIjoieDUwOV9zYW5fZG5zOmxvY2FsaG9zdDoxMjM0IiwidHJhbnNhY3Rpb25fZGF0YV9oYXNoZXMiOlsiWHd5VmQ3d0ZSRWRWV0xwbmk1UU5IZ2dOV1hvMko0TG41OHQyX2VjSjczcyJdLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOiJzaGEtMjU2Iiwic2RfaGFzaCI6IkJFQ09xRm9OMjM0UldtRzEtTUlSWXl5SnpXTDg1XzRLdTdHNC1KcUl4V0UifQ.ZnDZBS8o_WPsTlvuUO0SnARUIvx1M8t9Fd6TiaQbMtT_0OA7QCvdpisSh9-NfLAb40frAED875W8RI3zi06-DQ',
+                  path: undefined,
+                },
+              },
+            },
+          })
+
+          return HttpResponse.json({ message: 'completed' })
+        } catch (error) {
+          console.error(error)
+          return HttpResponse.error()
+        }
+      })
+    )
+
+    // verifier
+    const authorizationRequest = await createOpenid4vpAuthorizationRequest({
+      requestPayload,
+      callbacks,
+    })
+    expect(authorizationRequest).toMatchObject({
+      authRequestObject: requestPayload,
+      authRequest:
+        'openid4vp://?nonce=nonce&client_metadata=%7B%7D&response_mode=direct_post&dcql_query=%7B%22credentials%22%3A%5B%7B%22id%22%3A%22orgeuuniversity%22%2C%22format%22%3A%22mso_mdoc%22%2C%22meta%22%3A%7B%22doctype_value%22%3A%22org.eu.university%22%7D%2C%22claims%22%3A%5B%7B%22namespace%22%3A%22eu.europa.ec.eudi.pid.1%22%2C%22claim_name%22%3A%22name%22%7D%2C%7B%22namespace%22%3A%22eu.europa.ec.eudi.pid.1%22%2C%22claim_name%22%3A%22degree%22%7D%2C%7B%22namespace%22%3A%22eu.europa.ec.eudi.pid.1%22%2C%22claim_name%22%3A%22date%22%7D%5D%7D%2C%7B%22id%22%3A%22OpenBadgeCredentialDescriptor%22%2C%22format%22%3A%22dc%2Bsd-jwt%22%2C%22meta%22%3A%7B%22vct_values%22%3A%5B%22OpenBadgeCredential%22%5D%7D%2C%22claims%22%3A%5B%7B%22path%22%3A%5B%22university%22%5D%7D%5D%7D%5D%7D&response_uri=https%3A%2F%2Fexample.com%2Fresponse_uri&response_type=vp_token&client_id=client_id',
+      jar: undefined,
+    })
+
+    // holder
+
+    const resolved = await resolveOpenid4vpAuthorizationRequest({
+      requestPayload,
+      callbacks,
+    })
+
+    expect(resolved).toMatchObject({
+      transactionData: undefined,
+      requestPayload: {
+        response_type: 'vp_token',
+        client_id: 'client_id',
+        response_uri: 'https://example.com/response_uri',
+        response_mode: 'direct_post',
+        nonce: 'nonce',
+        dcql_query: exampleDcqlQuery,
+        client_metadata: {},
+      },
+      jar: undefined,
+      client: {
+        scheme: 'pre-registered',
+        identifier: 'client_id',
+        originalValue: 'client_id',
+        clientMetadata: {},
+      },
+      pex: undefined,
+      dcql: {
+        query: exampleDcqlQuery,
+      },
+    })
+
+    const response = await createOpenid4vpAuthorizationResponse({
+      requestPayload,
+      responsePayload: { vp_token: exampleVptoken },
+      callbacks,
+    })
+
+    expect(response).toMatchObject({
+      responsePayload: {
+        vp_token: {
+          orgeuuniversity:
+            'uQADZ3ZlcnNpb25jMS4waWRvY3VtZW50c4GjZ2RvY1R5cGVxb3JnLmV1LnVuaXZlcnNpdHlsaXNzdWVyU2lnbmVkuQACam5hbWVTcGFjZXOhd2V1LmV1cm9wYS5lYy5ldWRpLnBpZC4xg9gYWGGkaGRpZ2VzdElEA3FlbGVtZW50SWRlbnRpZmllcmRuYW1lbGVsZW1lbnRWYWx1ZWhKb2huIERvZWZyYW5kb21YIEWyJGCZTVxZPQlUipZgJrFHAG953ShscUxOhqcVj5zZ2BhYY6RoZGlnZXN0SUQBcWVsZW1lbnRJZGVudGlmaWVyZmRlZ3JlZWxlbGVtZW50VmFsdWVoYmFjaGVsb3JmcmFuZG9tWCAK5tJW8iDu2_pFMZbncXHsVSoMPB-j6NHzTidrmAwglNgYWGakaGRpZ2VzdElEAnFlbGVtZW50SWRlbnRpZmllcmRkYXRlbGVsZW1lbnRWYWx1ZdkD7GoyMDI1LTAyLTI3ZnJhbmRvbVggHkxQ5P0ym4b-S2YhPULns-6950O_pu1f01YH4KZf7RFqaXNzdWVyQXV0aIRDoQEmogRYMXpEbmFlYVpVV3dVUmpyNVE1TTJnMnVjZjE2bjNwVUx4bzRDaHFuZktYTnJNMk53MUsYIYFZAR4wggEaMIHAoAMCAQICEBe3X5XsrOs2ZhTfjDA0whkwCgYIKoZIzj0EAwIwDTELMAkGA1UEAxMCREUwHhcNMjUwMjI3MDkxOTMzWhcNMjYwMjI3MDkxOTMzWjANMQswCQYDVQQDEwJERTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJaBQfh-jpNhVxqwlTlv39Gm3nkewRvcA4p9TRao8YlC271XGo2ojTBcNh-RX65ql--tNygiJh6BHNhz98VPcVCjAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCx9YNNPzp7YPPdy4k3IVR_XLl6e7bnKS91cGEwArbMzgIhAIuglfUtfZM-ZYoEX1xYB47wMm666Trcykjag1sYMfgZWQIA2BhZAfu5AAZndmVyc2lvbmMxLjBvZGlnZXN0QWxnb3JpdGhtZ1NIQS0yNTZsdmFsdWVEaWdlc3RzoXdldS5ldXJvcGEuZWMuZXVkaS5waWQuMaUAWCAVPsuROLqNqsVsaaCrTJzdHdZ_IznS1nCh1qVKWZ2ezQFYIPeazaLvXv5M-s2h9713AG_QJcCZW-eu6UGzoGI6O9ZnAlggqnuFzR9wHj_51ftmjpqo5s-XIvjoLPw-5sfQ-IGtp1kDWCByQ8dnllyBLPNL1DgHqA0B8yAuvY-EoCVGmEAWMAbeowRYICrRJfwVhE9JJzLpa6tfc1LJ9rvv0sr2OzQ9ot-68CnNbWRldmljZUtleUluZm-5AAFpZGV2aWNlS2V5pAECIAEhWCAakKubHmMGh9_OHyUGEZ8102VOMM6j7C-MlEyHDyYJ1yJYIJbQibZhVZZ2ghRAClhsQO_fXpWcqRQKhriSZ4azbE2oZ2RvY1R5cGVxb3JnLmV1LnVuaXZlcnNpdHlsdmFsaWRpdHlJbmZvuQAEZnNpZ25lZMB0MjAyNS0wMi0yN1QwOToxOTozM1ppdmFsaWRGcm9twHQyMDI1LTAyLTI3VDA5OjE5OjMzWmp2YWxpZFVudGlswHQyMDI2LTAyLTI3VDA5OjE5OjMzWm5leHBlY3RlZFVwZGF0ZfdYQCFznxzCxRUqSe65YB3p1pjTEK7Sma4-JTUhnbwsdmtAoLBv5NMlu54mHj7oGCRBmN3G_un8GeX2opmG78yVdJNsZGV2aWNlU2lnbmVkuQACam5hbWVTcGFjZXPYGEGgamRldmljZUF1dGi5AAJvZGV2aWNlU2lnbmF0dXJlhEOhASag9lhA0kcpmpDK-lGZnNZ_cCjb_CbEz6UZ_MwymXE9r1j9YFrSpoahLj6dkprCZuaS1K79dvSZQTHw23KHzP_JAGFcj2lkZXZpY2VNYWP3ZnN0YXR1cwA',
+          OpenBadgeCredentialDescriptor:
+            'eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSIsImtpZCI6IiN6Nk1rcnpRUEJyNHB5cUM3NzZLS3RyejEzU2NoTTVlUFBic3N1UHVRWmI1dDR1S1EifQ.eyJ2Y3QiOiJPcGVuQmFkZ2VDcmVkZW50aWFsIiwiZGVncmVlIjoiYmFjaGVsb3IiLCJjbmYiOnsia2lkIjoiZGlkOmtleTp6Nk1rcEdSNGdzNFJjM1pwaDR2ajh3Um5qbkF4Z0FQU3hjUjhNQVZLdXRXc3BRemMjejZNa3BHUjRnczRSYzNacGg0dmo4d1Juam5BeGdBUFN4Y1I4TUFWS3V0V3NwUXpjIn0sImlzcyI6ImRpZDprZXk6ejZNa3J6UVBCcjRweXFDNzc2S0t0cnoxM1NjaE01ZVBQYnNzdVB1UVpiNXQ0dUtRIiwiaWF0IjoxNzQwNjQ3OTczLCJfc2QiOlsiSEtyNW1mYkE2OGRZY0JYZTVMRDREdFJHdjVoNWp0NEVDT2JSOWF5VkJCOCIsImlBYS1YVXhGaG1nU0g2SWhTOHZ2cm1TWF95VHJ2ZTQtZjFjTWRPLU41VUUiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.pP2G3YxexmDGpF-vfb04zMhVLLJGjkiVUiA-I-aLVdhNqzCjexOAu9xQOt0uTGT-4_ly_j66FXR2v4p0z9iyBw~WyI2NTgyNDY2MzM4MjYyODgyMjY2Nzc2MTkiLCJ1bml2ZXJzaXR5IiwiaW5uc2JydWNrIl0~eyJ0eXAiOiJrYitqd3QiLCJhbGciOiJFZERTQSJ9.eyJpYXQiOjE3NDA2NDc5NzYsIm5vbmNlIjoiNDczODIzNzM5Nzg4MzU1NzEyMTc3MzUwIiwiYXVkIjoieDUwOV9zYW5fZG5zOmxvY2FsaG9zdDoxMjM0IiwidHJhbnNhY3Rpb25fZGF0YV9oYXNoZXMiOlsiWHd5VmQ3d0ZSRWRWV0xwbmk1UU5IZ2dOV1hvMko0TG41OHQyX2VjSjczcyJdLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOiJzaGEtMjU2Iiwic2RfaGFzaCI6IkJFQ09xRm9OMjM0UldtRzEtTUlSWXl5SnpXTDg1XzRLdTdHNC1KcUl4V0UifQ.ZnDZBS8o_WPsTlvuUO0SnARUIvx1M8t9Fd6TiaQbMtT_0OA7QCvdpisSh9-NfLAb40frAED875W8RI3zi06-DQ',
+        },
+      },
+    })
+
+    const submissionResult = await submitOpenid4vpAuthorizationResponse({
+      responsePayload: response.responsePayload,
+      requestPayload: requestPayload,
+      callbacks,
+    })
+
+    expect(submissionResult.response.status).toBe(200)
+  })
+})

--- a/packages/openid4vp/tests/parse-client-identifier-scheme.test.ts
+++ b/packages/openid4vp/tests/parse-client-identifier-scheme.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from 'vitest'
+import { parseClientIdentifier } from '../src/client-identifier-scheme/parse-client-identifier-scheme'
+
+describe('Correctly parses the client identifier', () => {
+  describe('legacy client_id_scheme', () => {
+  test(`correctly handles legacy client_id_schme 'entity_id'`, () => {
+    const client = parseClientIdentifier({
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'https://example.com',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+        client_id_scheme: 'entity_id',
+      },
+      callbacks: {},
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'https://example.com',
+      originalValue: 'https://example.com',
+      scheme: 'https',
+      trustChain: undefined,
+    })
+  })
+
+  test(`correctly handles legacy client_id_schme 'did'`, () => {
+    const client = parseClientIdentifier({
+      // @ts-expect-error
+      jar: { signer: { publicJwk: { kid: 'did:example:123#key-1' } } },
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'did:example:123#key-1',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+        client_id_scheme: 'did',
+      },
+      callbacks: {},
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'did:example:123#key-1',
+      originalValue: 'did:example:123#key-1',
+      scheme: 'did',
+    })
+  })
+
+  test(`correctly handles legacy client_id_schme 'x509_san_dns'`, () => {
+    const client = parseClientIdentifier({
+      // @ts-expect-error
+      jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'example.com',
+        redirect_uri: 'https://example.com',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+        client_id_scheme: 'x509_san_dns',
+      },
+      callbacks: {
+        getX509CertificateMetadata: () => ({ sanDnsNames: ['example.com'], sanUriNames: [] }),
+      },
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'example.com',
+      originalValue: 'x509_san_dns:example.com',
+      scheme: 'x509_san_dns',
+    })
+  })
+
+  test(`correctly handles legacy client_id_schme 'x509_san_uri'`, () => {
+    const client = parseClientIdentifier({
+      // @ts-expect-error
+      jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'https://example.com',
+        redirect_uri: 'https://example.com',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+        client_id_scheme: 'x509_san_uri',
+      },
+      callbacks: {
+        getX509CertificateMetadata: () => ({ sanDnsNames: [], sanUriNames: ['https://example.com'] }),
+      },
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'https://example.com',
+      originalValue: 'x509_san_uri:https://example.com',
+      scheme: 'x509_san_uri',
+    })
+  })
+
+  test('correctly assumes no client_id_scheme as pre-registered', () => {
+    const client = parseClientIdentifier({
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'pre-registered client',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+      },
+      callbacks: {},
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'pre-registered client',
+      originalValue: 'pre-registered client',
+      scheme: 'pre-registered',
+    })
+  })
+
+  test('correctly applies pre-registered', () => {
+    const client = parseClientIdentifier({
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'pre-registered client',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+        client_id_scheme: 'pre-registered',
+      },
+      callbacks: {},
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'pre-registered client',
+      originalValue: 'pre-registered client',
+      scheme: 'pre-registered',
+    })
+  })
+})
+
+
+  describe('client_id_scheme', () => {
+  test(`correctly handles client_id_schme 'entity_id'`, () => {
+    const client = parseClientIdentifier({
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'https://example.com',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+      },
+      callbacks: {},
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'https://example.com',
+      originalValue: 'https://example.com',
+      scheme: 'https',
+      trustChain: undefined,
+    })
+  })
+
+  test(`correctly handles client_id_schme 'did'`, () => {
+    const client = parseClientIdentifier({
+      // @ts-expect-error
+      jar: { signer: { publicJwk: { kid: 'did:example:123#key-1' } } },
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'did:example:123#key-1',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+      },
+      callbacks: {},
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'did:example:123#key-1',
+      originalValue: 'did:example:123#key-1',
+      scheme: 'did',
+    })
+  })
+
+  test(`correctly handles client_id_schme 'x509_san_dns'`, () => {
+    const client = parseClientIdentifier({
+      // @ts-expect-error
+      jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'x509_san_dns:example.com',
+        redirect_uri: 'https://example.com',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+      },
+      callbacks: {
+        getX509CertificateMetadata: () => ({ sanDnsNames: ['example.com'], sanUriNames: [] }),
+      },
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'example.com',
+      originalValue: 'x509_san_dns:example.com',
+      scheme: 'x509_san_dns',
+    })
+  })
+
+  test(`correctly handles legacy client_id_schme 'x509_san_uri'`, () => {
+    const client = parseClientIdentifier({
+      // @ts-expect-error
+      jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'x509_san_uri:https://example.com',
+        redirect_uri: 'https://example.com',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+      },
+      callbacks: {
+        getX509CertificateMetadata: () => ({ sanDnsNames: [], sanUriNames: ['https://example.com'] }),
+      },
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'https://example.com',
+      originalValue: 'x509_san_uri:https://example.com',
+      scheme: 'x509_san_uri',
+    })
+  })
+
+  test('correctly assumes no client_id_scheme as pre-registered', () => {
+    const client = parseClientIdentifier({
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'pre-registered client',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+      },
+      callbacks: {},
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'pre-registered client',
+      originalValue: 'pre-registered client',
+      scheme: 'pre-registered',
+    })
+  })
+
+  test('correctly applies pre-registered', () => {
+    const client = parseClientIdentifier({
+      request: {
+        response_mode: 'direct_post',
+        client_id: 'pre-registered:pre-registered client',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+      },
+      callbacks: {},
+    })
+
+    expect(client).toMatchObject({
+      identifier: 'pre-registered client',
+      originalValue: 'pre-registered:pre-registered client',
+      scheme: 'pre-registered',
+    })
+  })
+})
+})

--- a/packages/openid4vp/tests/parse-client-identifier-scheme.test.ts
+++ b/packages/openid4vp/tests/parse-client-identifier-scheme.test.ts
@@ -3,254 +3,253 @@ import { parseClientIdentifier } from '../src/client-identifier-scheme/parse-cli
 
 describe('Correctly parses the client identifier', () => {
   describe('legacy client_id_scheme', () => {
-  test(`correctly handles legacy client_id_schme 'entity_id'`, () => {
-    const client = parseClientIdentifier({
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'https://example.com',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-        client_id_scheme: 'entity_id',
-      },
-      callbacks: {},
+    test(`correctly handles legacy client_id_schme 'entity_id'`, () => {
+      const client = parseClientIdentifier({
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'https://example.com',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+          client_id_scheme: 'entity_id',
+        },
+        callbacks: {},
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'https://example.com',
+        originalValue: 'https://example.com',
+        scheme: 'https',
+        trustChain: undefined,
+      })
     })
 
-    expect(client).toMatchObject({
-      identifier: 'https://example.com',
-      originalValue: 'https://example.com',
-      scheme: 'https',
-      trustChain: undefined,
+    test(`correctly handles legacy client_id_schme 'did'`, () => {
+      const client = parseClientIdentifier({
+        // @ts-expect-error
+        jar: { signer: { publicJwk: { kid: 'did:example:123#key-1' } } },
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'did:example:123#key-1',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+          client_id_scheme: 'did',
+        },
+        callbacks: {},
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'did:example:123#key-1',
+        originalValue: 'did:example:123#key-1',
+        scheme: 'did',
+      })
+    })
+
+    test(`correctly handles legacy client_id_schme 'x509_san_dns'`, () => {
+      const client = parseClientIdentifier({
+        // @ts-expect-error
+        jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'example.com',
+          redirect_uri: 'https://example.com',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+          client_id_scheme: 'x509_san_dns',
+        },
+        callbacks: {
+          getX509CertificateMetadata: () => ({ sanDnsNames: ['example.com'], sanUriNames: [] }),
+        },
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'example.com',
+        originalValue: 'x509_san_dns:example.com',
+        scheme: 'x509_san_dns',
+      })
+    })
+
+    test(`correctly handles legacy client_id_schme 'x509_san_uri'`, () => {
+      const client = parseClientIdentifier({
+        // @ts-expect-error
+        jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'https://example.com',
+          redirect_uri: 'https://example.com',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+          client_id_scheme: 'x509_san_uri',
+        },
+        callbacks: {
+          getX509CertificateMetadata: () => ({ sanDnsNames: [], sanUriNames: ['https://example.com'] }),
+        },
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'https://example.com',
+        originalValue: 'x509_san_uri:https://example.com',
+        scheme: 'x509_san_uri',
+      })
+    })
+
+    test('correctly assumes no client_id_scheme as pre-registered', () => {
+      const client = parseClientIdentifier({
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'pre-registered client',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+        },
+        callbacks: {},
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'pre-registered client',
+        originalValue: 'pre-registered client',
+        scheme: 'pre-registered',
+      })
+    })
+
+    test('correctly applies pre-registered', () => {
+      const client = parseClientIdentifier({
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'pre-registered client',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+          client_id_scheme: 'pre-registered',
+        },
+        callbacks: {},
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'pre-registered client',
+        originalValue: 'pre-registered client',
+        scheme: 'pre-registered',
+      })
     })
   })
-
-  test(`correctly handles legacy client_id_schme 'did'`, () => {
-    const client = parseClientIdentifier({
-      // @ts-expect-error
-      jar: { signer: { publicJwk: { kid: 'did:example:123#key-1' } } },
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'did:example:123#key-1',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-        client_id_scheme: 'did',
-      },
-      callbacks: {},
-    })
-
-    expect(client).toMatchObject({
-      identifier: 'did:example:123#key-1',
-      originalValue: 'did:example:123#key-1',
-      scheme: 'did',
-    })
-  })
-
-  test(`correctly handles legacy client_id_schme 'x509_san_dns'`, () => {
-    const client = parseClientIdentifier({
-      // @ts-expect-error
-      jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'example.com',
-        redirect_uri: 'https://example.com',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-        client_id_scheme: 'x509_san_dns',
-      },
-      callbacks: {
-        getX509CertificateMetadata: () => ({ sanDnsNames: ['example.com'], sanUriNames: [] }),
-      },
-    })
-
-    expect(client).toMatchObject({
-      identifier: 'example.com',
-      originalValue: 'x509_san_dns:example.com',
-      scheme: 'x509_san_dns',
-    })
-  })
-
-  test(`correctly handles legacy client_id_schme 'x509_san_uri'`, () => {
-    const client = parseClientIdentifier({
-      // @ts-expect-error
-      jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'https://example.com',
-        redirect_uri: 'https://example.com',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-        client_id_scheme: 'x509_san_uri',
-      },
-      callbacks: {
-        getX509CertificateMetadata: () => ({ sanDnsNames: [], sanUriNames: ['https://example.com'] }),
-      },
-    })
-
-    expect(client).toMatchObject({
-      identifier: 'https://example.com',
-      originalValue: 'x509_san_uri:https://example.com',
-      scheme: 'x509_san_uri',
-    })
-  })
-
-  test('correctly assumes no client_id_scheme as pre-registered', () => {
-    const client = parseClientIdentifier({
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'pre-registered client',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-      },
-      callbacks: {},
-    })
-
-    expect(client).toMatchObject({
-      identifier: 'pre-registered client',
-      originalValue: 'pre-registered client',
-      scheme: 'pre-registered',
-    })
-  })
-
-  test('correctly applies pre-registered', () => {
-    const client = parseClientIdentifier({
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'pre-registered client',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-        client_id_scheme: 'pre-registered',
-      },
-      callbacks: {},
-    })
-
-    expect(client).toMatchObject({
-      identifier: 'pre-registered client',
-      originalValue: 'pre-registered client',
-      scheme: 'pre-registered',
-    })
-  })
-})
-
 
   describe('client_id_scheme', () => {
-  test(`correctly handles client_id_schme 'entity_id'`, () => {
-    const client = parseClientIdentifier({
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'https://example.com',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-      },
-      callbacks: {},
+    test(`correctly handles client_id_schme 'entity_id'`, () => {
+      const client = parseClientIdentifier({
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'https://example.com',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+        },
+        callbacks: {},
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'https://example.com',
+        originalValue: 'https://example.com',
+        scheme: 'https',
+        trustChain: undefined,
+      })
     })
 
-    expect(client).toMatchObject({
-      identifier: 'https://example.com',
-      originalValue: 'https://example.com',
-      scheme: 'https',
-      trustChain: undefined,
+    test(`correctly handles client_id_schme 'did'`, () => {
+      const client = parseClientIdentifier({
+        // @ts-expect-error
+        jar: { signer: { publicJwk: { kid: 'did:example:123#key-1' } } },
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'did:example:123#key-1',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+        },
+        callbacks: {},
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'did:example:123#key-1',
+        originalValue: 'did:example:123#key-1',
+        scheme: 'did',
+      })
+    })
+
+    test(`correctly handles client_id_schme 'x509_san_dns'`, () => {
+      const client = parseClientIdentifier({
+        // @ts-expect-error
+        jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'x509_san_dns:example.com',
+          redirect_uri: 'https://example.com',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+        },
+        callbacks: {
+          getX509CertificateMetadata: () => ({ sanDnsNames: ['example.com'], sanUriNames: [] }),
+        },
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'example.com',
+        originalValue: 'x509_san_dns:example.com',
+        scheme: 'x509_san_dns',
+      })
+    })
+
+    test(`correctly handles legacy client_id_schme 'x509_san_uri'`, () => {
+      const client = parseClientIdentifier({
+        // @ts-expect-error
+        jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'x509_san_uri:https://example.com',
+          redirect_uri: 'https://example.com',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+        },
+        callbacks: {
+          getX509CertificateMetadata: () => ({ sanDnsNames: [], sanUriNames: ['https://example.com'] }),
+        },
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'https://example.com',
+        originalValue: 'x509_san_uri:https://example.com',
+        scheme: 'x509_san_uri',
+      })
+    })
+
+    test('correctly assumes no client_id_scheme as pre-registered', () => {
+      const client = parseClientIdentifier({
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'pre-registered client',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+        },
+        callbacks: {},
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'pre-registered client',
+        originalValue: 'pre-registered client',
+        scheme: 'pre-registered',
+      })
+    })
+
+    test('correctly applies pre-registered', () => {
+      const client = parseClientIdentifier({
+        request: {
+          response_mode: 'direct_post',
+          client_id: 'pre-registered:pre-registered client',
+          nonce: 'nonce',
+          response_type: 'vp_token',
+        },
+        callbacks: {},
+      })
+
+      expect(client).toMatchObject({
+        identifier: 'pre-registered client',
+        originalValue: 'pre-registered:pre-registered client',
+        scheme: 'pre-registered',
+      })
     })
   })
-
-  test(`correctly handles client_id_schme 'did'`, () => {
-    const client = parseClientIdentifier({
-      // @ts-expect-error
-      jar: { signer: { publicJwk: { kid: 'did:example:123#key-1' } } },
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'did:example:123#key-1',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-      },
-      callbacks: {},
-    })
-
-    expect(client).toMatchObject({
-      identifier: 'did:example:123#key-1',
-      originalValue: 'did:example:123#key-1',
-      scheme: 'did',
-    })
-  })
-
-  test(`correctly handles client_id_schme 'x509_san_dns'`, () => {
-    const client = parseClientIdentifier({
-      // @ts-expect-error
-      jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'x509_san_dns:example.com',
-        redirect_uri: 'https://example.com',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-      },
-      callbacks: {
-        getX509CertificateMetadata: () => ({ sanDnsNames: ['example.com'], sanUriNames: [] }),
-      },
-    })
-
-    expect(client).toMatchObject({
-      identifier: 'example.com',
-      originalValue: 'x509_san_dns:example.com',
-      scheme: 'x509_san_dns',
-    })
-  })
-
-  test(`correctly handles legacy client_id_schme 'x509_san_uri'`, () => {
-    const client = parseClientIdentifier({
-      // @ts-expect-error
-      jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'x509_san_uri:https://example.com',
-        redirect_uri: 'https://example.com',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-      },
-      callbacks: {
-        getX509CertificateMetadata: () => ({ sanDnsNames: [], sanUriNames: ['https://example.com'] }),
-      },
-    })
-
-    expect(client).toMatchObject({
-      identifier: 'https://example.com',
-      originalValue: 'x509_san_uri:https://example.com',
-      scheme: 'x509_san_uri',
-    })
-  })
-
-  test('correctly assumes no client_id_scheme as pre-registered', () => {
-    const client = parseClientIdentifier({
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'pre-registered client',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-      },
-      callbacks: {},
-    })
-
-    expect(client).toMatchObject({
-      identifier: 'pre-registered client',
-      originalValue: 'pre-registered client',
-      scheme: 'pre-registered',
-    })
-  })
-
-  test('correctly applies pre-registered', () => {
-    const client = parseClientIdentifier({
-      request: {
-        response_mode: 'direct_post',
-        client_id: 'pre-registered:pre-registered client',
-        nonce: 'nonce',
-        response_type: 'vp_token',
-      },
-      callbacks: {},
-    })
-
-    expect(client).toMatchObject({
-      identifier: 'pre-registered client',
-      originalValue: 'pre-registered:pre-registered client',
-      scheme: 'pre-registered',
-    })
-  })
-})
 })

--- a/packages/openid4vp/tests/version-inference.test.ts
+++ b/packages/openid4vp/tests/version-inference.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest'
+import { parseAuthorizationRequestVersion } from '../src/version'
+
+describe('Version inference test', () => {
+  test('w3c_dc_api is only available in v22 and below', () => {
+    const version = parseAuthorizationRequestVersion({
+      response_mode: 'w3c_dc_api',
+      nonce: 'nonce',
+      response_type: 'vp_token',
+    })
+
+    expect(version).toBe(22)
+  })
+
+  test('dc_api is only available from v23', () => {
+    const version = parseAuthorizationRequestVersion({
+      response_mode: 'dc_api',
+      nonce: 'nonce',
+      response_type: 'vp_token',
+    })
+
+    expect(version).toBe(24)
+  })
+
+  test('client_metadata_uri requires version below 21', () => {
+    const version = parseAuthorizationRequestVersion({
+      response_mode: 'direct_post',
+      client_id: 'client_id',
+      nonce: 'nonce',
+      response_type: 'vp_token',
+      client_metadata_uri: 'https://example.com',
+    })
+
+    expect(version).toBe(20)
+  })
+
+  test('client_metadata_uri requires version below 21, dcql is available from v22', () => {
+    expect(() =>
+      parseAuthorizationRequestVersion({
+        response_mode: 'direct_post',
+        client_id: 'client_id',
+        nonce: 'nonce',
+        response_type: 'vp_token',
+        client_metadata_uri: 'https://example.com',
+        dcql_query: {},
+      })
+    ).throws()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,19 +571,9 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@rollup/rollup-android-arm-eabi@4.24.0':
-    resolution: {integrity: sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.34.2':
     resolution: {integrity: sha512-6Fyg9yQbwJR+ykVdT9sid1oc2ewejS6h4wzQltmJfSW53N60G/ah9pngXGANdy9/aaE/TcUFpWosdm7JXS1WTQ==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.24.0':
-    resolution: {integrity: sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.34.2':
@@ -591,19 +581,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.24.0':
-    resolution: {integrity: sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.34.2':
     resolution: {integrity: sha512-PSN58XG/V/tzqDb9kDGutUruycgylMlUE59f40ny6QIRNsTEIZsrNQTJKUN2keMMSmlzgunMFqyaGLmly39sug==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.24.0':
-    resolution: {integrity: sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.34.2':
@@ -621,18 +601,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.24.0':
-    resolution: {integrity: sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.34.2':
     resolution: {integrity: sha512-lfqTpWjSvbgQP1vqGTXdv+/kxIznKXZlI109WkIFPbud41bjigjNmOAAKoazmRGx+k9e3rtIdbq2pQZPV1pMig==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.24.0':
-    resolution: {integrity: sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==}
     cpu: [arm]
     os: [linux]
 
@@ -641,18 +611,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.24.0':
-    resolution: {integrity: sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.34.2':
     resolution: {integrity: sha512-ZvkPiheyXtXlFqHpsdgscx+tZ7hoR59vOettvArinEspq5fxSDSgfF+L5wqqJ9R4t+n53nyn0sKxeXlik7AY9Q==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.24.0':
-    resolution: {integrity: sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==}
     cpu: [arm64]
     os: [linux]
 
@@ -666,19 +626,9 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.24.0':
-    resolution: {integrity: sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==}
-    cpu: [ppc64]
-    os: [linux]
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.2':
     resolution: {integrity: sha512-g/O5IpgtrQqPegvqopvmdCF9vneLE7eqYfdPWW8yjPS8f63DNam3U4ARL1PNNB64XHZDHKpvO2Giftf43puB8Q==}
     cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.24.0':
-    resolution: {integrity: sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==}
-    cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.2':
@@ -686,28 +636,13 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.24.0':
-    resolution: {integrity: sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.34.2':
     resolution: {integrity: sha512-49TtdeVAsdRuiUHXPrFVucaP4SivazetGUVH8CIxVsNsaPHV4PFkpLmH9LeqU/R4Nbgky9lzX5Xe1NrzLyraVA==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.24.0':
-    resolution: {integrity: sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.34.2':
     resolution: {integrity: sha512-j+jFdfOycLIQ7FWKka9Zd3qvsIyugg5LeZuHF6kFlXo6MSOc6R1w37YUVy8VpAKd81LMWGi5g9J25P09M0SSIw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.24.0':
-    resolution: {integrity: sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==}
     cpu: [x64]
     os: [linux]
 
@@ -716,29 +651,14 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.24.0':
-    resolution: {integrity: sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.34.2':
     resolution: {integrity: sha512-LQRkCyUBnAo7r8dbEdtNU08EKLCJMgAk2oP5H3R7BnUlKLqgR3dUjrLBVirmc1RK6U6qhtDw29Dimeer8d5hzQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.24.0':
-    resolution: {integrity: sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.34.2':
     resolution: {integrity: sha512-wt8OhpQUi6JuPFkm1wbVi1BByeag87LDFzeKSXzIdGcX4bMLqORTtKxLoCbV57BHYNSUSOKlSL4BYYUghainYA==}
     cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.24.0':
-    resolution: {integrity: sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==}
-    cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.34.2':
@@ -917,15 +837,6 @@ packages:
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
-
-  debug@4.3.7:
-    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
@@ -1360,11 +1271,6 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup@4.24.0:
-    resolution: {integrity: sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.34.2:
     resolution: {integrity: sha512-sBDUoxZEaqLu9QeNalL8v3jw6WjPku4wfZGyTU7l7m1oC+rpRihXc/n/H+4148ZkGz5Xli8CHMns//fFGKvpIQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1480,9 +1386,6 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinyexec@0.3.1:
-    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -2124,25 +2027,13 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.24.0':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.34.2':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.24.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.34.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.24.0':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.34.2':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.24.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.34.2':
@@ -2154,25 +2045,13 @@ snapshots:
   '@rollup/rollup-freebsd-x64@4.34.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.24.0':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.34.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.24.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.24.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.34.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.24.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.34.2':
@@ -2181,49 +2060,25 @@ snapshots:
   '@rollup/rollup-linux-loongarch64-gnu@4.34.2':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.24.0':
-    optional: true
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.24.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.24.0':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.34.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.24.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.34.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.24.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.34.2':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.24.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.34.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.24.0':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.34.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.34.2':
@@ -2392,10 +2247,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
 
   debug@4.4.0:
     dependencies:
@@ -2796,28 +2647,6 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rollup@4.24.0:
-    dependencies:
-      '@types/estree': 1.0.6
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.24.0
-      '@rollup/rollup-android-arm64': 4.24.0
-      '@rollup/rollup-darwin-arm64': 4.24.0
-      '@rollup/rollup-darwin-x64': 4.24.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.24.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.24.0
-      '@rollup/rollup-linux-arm64-gnu': 4.24.0
-      '@rollup/rollup-linux-arm64-musl': 4.24.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.24.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.24.0
-      '@rollup/rollup-linux-s390x-gnu': 4.24.0
-      '@rollup/rollup-linux-x64-gnu': 4.24.0
-      '@rollup/rollup-linux-x64-musl': 4.24.0
-      '@rollup/rollup-win32-arm64-msvc': 4.24.0
-      '@rollup/rollup-win32-ia32-msvc': 4.24.0
-      '@rollup/rollup-win32-x64-msvc': 4.24.0
-      fsevents: 2.3.3
-
   rollup@4.34.2:
     dependencies:
       '@types/estree': 1.0.6
@@ -2940,8 +2769,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.1: {}
-
   tinyexec@0.3.2: {}
 
   tinyglobby@0.2.9:
@@ -2984,16 +2811,16 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.1
       consola: 3.2.3
-      debug: 4.3.7
+      debug: 4.4.0
       esbuild: 0.24.0
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(postcss@8.5.1)
       resolve-from: 5.0.0
-      rollup: 4.24.0
+      rollup: 4.34.2
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
       tinyglobby: 0.2.9
       tree-kill: 1.2.2
     optionalDependencies:


### PR DESCRIPTION
Adds support for v18-v24


TODO: 
- [ ] client_metadata_uri handling
- [ ] are mdoc related changes required?

**bold** means changes should be taken into cosideration
__italic__ means needs to be taken into consideration outside of the vp lib
~~strikethrough~~ should not be relevant

-24
__add mdoc specific intent_to_retain mechanism, using the definition from 18013-5__
~~require typ value in request object to be oauth-authz-req+jwt~~ we always enfore this
~~add SessionTranscript requirements~~
__use claims path pointer for mdoc based credential__
**client_id_scheme and turn it into a prefix of the client_id; this addresses a security issue with the previous solution**
~~Clarified what can go in the client_metadata parameter~~
~~Fixed #227: Enabled non-breaking extensibility.~~
~~Fixed #383: Completed IANA Considerations section.~~

-23

~~fixed percent-encoding of URI examples~~
~~fixed an example that used 'client' where 'wallet' is more appropriate~~
~~make SIOP example request/response consistent with each other~~
~~make example request and example SD-JWT key binding JWT consistent~~
~~add note that there are a choice of encryption JWE algorithms available, including the HPKE draft~~
**add transaction_data & dcql_query to list of allowed parameters in W3C Digital Credentials API appendix**
**change credential format identifier vc+sd-jwt to dc+sd-jwt to align with the media type in draft -06 of [I-D.ietf-oauth-sd-jwt-vc] and update typ accordingly in examples**
~~remove references to the openid4vci credential format section~~
~~clarified what profiling OID4VP means~~
~~moved credential format specific DCQL parameters to the annex~~
~~generalized W3C Digital Credentials API references~~
**changed response mode value for the OID4VP over the DC API**
__updated to PE ver 2.1.1 (used to be 2.0.0)__


-22

**Introduced the Digital Credentials Query Language**
**add transaction data mechanism**
**remove client_id_scheme and turn it into a prefix of the client_id; this addresses a security issue with the previous solution**
~~Clarified what can go in the client_metadata parameter~~
~~Fixed #227: Enabled non-breaking extensibility.~~
~~Fixed #383: Completed IANA Considerations section.~~

-21
**removed client_metadata_uri authorization parameter**
**added how OpenID4VP request/response can be used over the browser API**
~~remove path_nested description from Response Parameters section and move it into W3C VC Annex~~
~~fix indentation of examples~~
~~added references to ISO/IEC 23220 and 18013 documents~~
**added post request method for Request URI**
~~Added IETF SD-JWT VC profile~~ i don't think we need to do anything here
~~Added wallet_unavailable error~~ let's ignore this

-20
**added "verifier_attestation" client id scheme value**

-19
**added "x509_san_uri" and "x509_san_dns" client id scheme value**

-18
~~editorial update based on the 45 days review period prior to the Vote for proposed Second Implementer's Draft~~