### PR TITLE
feat: improved jwt signer parsing and federation handling

### DIFF
--- a/.changeset/red-ladybugs-perform.md
+++ b/.changeset/red-ladybugs-perform.md
@@ -1,0 +1,7 @@
+---
+"@openid4vc/openid4vp": minor
+"@openid4vc/oauth2": minor
+"@openid4vc/openid4vci": minor
+---
+
+refactor: change the jwt signer method 'trustChain' to 'federation' and make 'trustChain' variable optional.

--- a/packages/oauth2/src/common/jwt/__tests__/decode-jwt.test.ts
+++ b/packages/oauth2/src/common/jwt/__tests__/decode-jwt.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'vitest'
+import { jwtSignerFromJwt } from '../decode-jwt'
+
+describe('Decode JWT', () => {
+  describe('jwtSignerFromJwt', () => {
+    test('x5c header', () => {
+      expect(jwtSignerFromJwt({ header: { x5c: ['cert'], alg: 'ES256' }, payload: {} })).toEqual({
+        method: 'x5c',
+        x5c: ['cert'],
+        alg: 'ES256',
+      })
+    })
+
+    test('did kid header', () => {
+      expect(jwtSignerFromJwt({ header: { kid: 'did:web:example.com#123', alg: 'ES256' }, payload: {} })).toEqual({
+        method: 'did',
+        didUrl: 'did:web:example.com#123',
+        alg: 'ES256',
+      })
+    })
+
+    test('did kid header with iss', () => {
+      expect(
+        jwtSignerFromJwt({ header: { kid: '#123', alg: 'ES256' }, payload: { iss: 'did:web:example.com' } })
+      ).toEqual({
+        method: 'did',
+        didUrl: 'did:web:example.com#123',
+        alg: 'ES256',
+      })
+    })
+
+    test('did in kid mismatch with iss', () => {
+      expect(() =>
+        jwtSignerFromJwt({
+          header: { kid: 'did:web:example.nl#123', alg: 'ES256' },
+          payload: { iss: 'did:web:example.com' },
+        })
+      ).toThrow(
+        `Unable to extract signer method from jwt. Found 1 allowed signer method(s) but contained invalid configuration:
+❌ method did: kid in header starst with did that is different from did value in 'iss'`
+      )
+    })
+
+    test('iss did but kid does not start with #', () => {
+      expect(() =>
+        jwtSignerFromJwt({
+          header: { kid: '123', alg: 'ES256' },
+          payload: { iss: 'did:web:example.com' },
+        })
+      ).toThrow(
+        `Unable to extract signer method from jwt. Found 1 allowed signer method(s) but contained invalid configuration:
+❌ method did: kid in header must start with either 'did:' or '#' when 'iss' value is a did`
+      )
+    })
+
+    test('jwk header', () => {
+      expect(
+        jwtSignerFromJwt({
+          header: {
+            // @ts-ignore
+            jwk: { kid: 'kid' },
+            alg: 'ES256',
+          },
+          payload: {},
+        })
+      ).toEqual({
+        method: 'jwk',
+        publicJwk: {
+          kid: 'kid',
+        },
+        alg: 'ES256',
+      })
+    })
+
+    test('custom', () => {
+      expect(
+        jwtSignerFromJwt({
+          header: {
+            alg: 'ES256',
+          },
+          payload: {},
+        })
+      ).toEqual({
+        method: 'custom',
+        alg: 'ES256',
+      })
+    })
+
+    test('allowed methods success', () => {
+      expect(
+        jwtSignerFromJwt({
+          header: {
+            alg: 'ES256',
+            kid: 'did:example:123#123',
+          },
+          payload: {},
+          allowedSignerMethods: ['did'],
+        })
+      ).toEqual({
+        method: 'did',
+        didUrl: 'did:example:123#123',
+        alg: 'ES256',
+      })
+    })
+
+    test('allowed methods error with valid methods', () => {
+      expect(() =>
+        jwtSignerFromJwt({
+          header: {
+            alg: 'ES256',
+            kid: 'did:example:123#123',
+          },
+          payload: {},
+          allowedSignerMethods: [],
+        })
+      ).toThrow(`Unable to extract signer method from jwt. Found 1 signer method(s) that are not allowed:
+✅ method did`)
+    })
+
+    test('allowed methods error with valid and invalid methods', () => {
+      expect(() =>
+        jwtSignerFromJwt({
+          header: {
+            alg: 'ES256',
+            kid: 'did:example.com#123',
+            // @ts-ignore
+            jwk: {},
+            trust_chain: [''],
+            x5c: ['cert'],
+          },
+          payload: { iss: 'did:examle.nl' },
+          allowedSignerMethods: [],
+        })
+      ).toThrow(`Unable to extract signer method from jwt. Found 4 signer method(s) that are not allowed:
+✅ method x5c
+✅ method federation
+❌ method did: kid in header starst with did that is different from did value in 'iss'
+✅ method jwk`)
+    })
+
+    test('no allowed methods no custom', () => {
+      expect(() =>
+        jwtSignerFromJwt({
+          header: {
+            alg: 'ES256',
+          },
+          payload: {},
+          allowedSignerMethods: [],
+        })
+      ).toThrow(
+        `Unable to extract signer method from jwt. Found no signer methods and 'custom' signer method is not allowed.`
+      )
+    })
+  })
+})

--- a/packages/oauth2/src/common/jwt/__tests__/decode-jwt.test.ts
+++ b/packages/oauth2/src/common/jwt/__tests__/decode-jwt.test.ts
@@ -37,7 +37,7 @@ describe('Decode JWT', () => {
         })
       ).toThrow(
         `Unable to extract signer method from jwt. Found 1 allowed signer method(s) but contained invalid configuration:
-❌ method did: kid in header starst with did that is different from did value in 'iss'`
+FAILED: method did - kid in header starst with did that is different from did value in 'iss'`
       )
     })
 
@@ -49,7 +49,7 @@ describe('Decode JWT', () => {
         })
       ).toThrow(
         `Unable to extract signer method from jwt. Found 1 allowed signer method(s) but contained invalid configuration:
-❌ method did: kid in header must start with either 'did:' or '#' when 'iss' value is a did`
+FAILED: method did - kid in header must start with either 'did:' or '#' when 'iss' value is a did`
       )
     })
 
@@ -114,7 +114,7 @@ describe('Decode JWT', () => {
           allowedSignerMethods: [],
         })
       ).toThrow(`Unable to extract signer method from jwt. Found 1 signer method(s) that are not allowed:
-✅ method did`)
+SUCCEEDED: method did`)
     })
 
     test('allowed methods error with valid and invalid methods', () => {
@@ -132,10 +132,10 @@ describe('Decode JWT', () => {
           allowedSignerMethods: [],
         })
       ).toThrow(`Unable to extract signer method from jwt. Found 4 signer method(s) that are not allowed:
-✅ method x5c
-✅ method federation
-❌ method did: kid in header starst with did that is different from did value in 'iss'
-✅ method jwk`)
+SUCCEEDED: method x5c
+SUCCEEDED: method federation
+FAILED: method did - kid in header starst with did that is different from did value in 'iss'
+SUCCEEDED: method jwk`)
     })
 
     test('no allowed methods no custom', () => {

--- a/packages/oauth2/src/common/jwt/decode-jwt.ts
+++ b/packages/oauth2/src/common/jwt/decode-jwt.ts
@@ -193,14 +193,14 @@ export function jwtSignerFromJwt({
 
   if (allowedFoundMethods.length > 0) {
     throw new Oauth2Error(
-      `Unable to extract signer method from jwt. Found ${allowedFoundMethods.length} allowed signer method(s) but contained invalid configuration:\n${allowedFoundMethods.map((m) => (m.valid ? '' : `❌ method ${m.method}: ${m.error}`)).join('\n')}`
+      `Unable to extract signer method from jwt. Found ${allowedFoundMethods.length} allowed signer method(s) but contained invalid configuration:\n${allowedFoundMethods.map((m) => (m.valid ? '' : `FAILED: method ${m.method} - ${m.error}`)).join('\n')}`
     )
   }
 
   // Found x5c, allowed jwk
   if (found.length > 0) {
     throw new Oauth2Error(
-      `Unable to extract signer method from jwt. Found ${found.length} signer method(s) that are not allowed:\n${found.map((m) => (m.valid ? `✅ method ${m.method}` : `❌ method ${m.method}: ${m.error}`)).join('\n')}`
+      `Unable to extract signer method from jwt. Found ${found.length} signer method(s) that are not allowed:\n${found.map((m) => (m.valid ? `SUCCEEDED: method ${m.method}` : `FAILED: method ${m.method} - ${m.error}`)).join('\n')}`
     )
   }
 

--- a/packages/oauth2/src/common/jwt/z-jwt.ts
+++ b/packages/oauth2/src/common/jwt/z-jwt.ts
@@ -21,9 +21,9 @@ export type JwtSignerX5c = {
   alg: string
 }
 
-export type JwtSignerTrustChain = {
-  method: 'trustChain'
-  trustChain: string[]
+export type JwtSignerFederation = {
+  method: 'federation'
+  trustChain?: [string, ...string[]]
   alg: string
   kid: string
 }
@@ -34,7 +34,7 @@ export type JwtSignerCustom = {
   alg: string
 }
 
-export type JwtSigner = JwtSignerDid | JwtSignerJwk | JwtSignerX5c | JwtSignerTrustChain | JwtSignerCustom
+export type JwtSigner = JwtSignerDid | JwtSignerJwk | JwtSignerX5c | JwtSignerFederation | JwtSignerCustom
 
 export type JwtSignerWithJwk = JwtSigner & { publicJwk: Jwk }
 
@@ -71,6 +71,9 @@ export const zJwtPayload = z
 
     // Reserved for status parameters
     status: z.record(z.string(), z.any()).optional(),
+
+    // Reserved for OpenID Federation
+    trust_chain: z.array(z.string()).nonempty().optional(),
   })
   .passthrough()
 
@@ -84,7 +87,9 @@ export const zJwtHeader = z
     kid: z.string().optional(),
     jwk: zJwk.optional(),
     x5c: z.array(z.string()).optional(),
-    trust_chain: z.array(z.string()).optional(),
+
+    // Reserved for OpenID Federation
+    trust_chain: z.array(z.string()).nonempty().optional(),
   })
   .passthrough()
 

--- a/packages/openid4vp/src/authorization-request/resolve-authorization-request.ts
+++ b/packages/openid4vp/src/authorization-request/resolve-authorization-request.ts
@@ -3,7 +3,7 @@ import { parseWithErrorHandling } from '@openid4vc/utils'
 import z from 'zod'
 import {
   type ParsedClientIdentifier,
-  parseClientIdentifier,
+  validateOpenid4vpClientId,
 } from '../client-identifier-scheme/parse-client-identifier-scheme'
 import { fetchClientMetadata } from '../fetch-client-metadata'
 import { type VerifiedJarRequest, verifyJarRequest } from '../jar/handle-jar-request/verify-jar-request'
@@ -99,7 +99,7 @@ export async function resolveOpenid4vpAuthorizationRequest(
     clientMetadata = await fetchClientMetadata({ clientMetadataUri: authorizationRequestPayload.client_metadata_uri })
   }
 
-  const clientMeta = parseClientIdentifier({
+  const clientMeta = validateOpenid4vpClientId({
     authorizationRequestPayload: {
       ...authorizationRequestPayload,
       client_metadata: clientMetadata,

--- a/packages/openid4vp/src/authorization-request/z-authorization-request-dc-api.ts
+++ b/packages/openid4vp/src/authorization-request/z-authorization-request-dc-api.ts
@@ -28,13 +28,17 @@ export const zOpenid4vpAuthorizationRequestDcApi = zOpenid4vpAuthorizationReques
 
 export type Openid4vpAuthorizationRequestDcApi = z.infer<typeof zOpenid4vpAuthorizationRequestDcApi>
 
+export function isOpenid4vpResponseModeDcApi(
+  responseMode: unknown
+): responseMode is Openid4vpAuthorizationRequestDcApi['response_mode'] {
+  return (
+    responseMode !== undefined &&
+    zOpenid4vpResponseModeDcApi.options.includes(responseMode as Openid4vpAuthorizationRequestDcApi['response_mode'])
+  )
+}
+
 export function isOpenid4vpAuthorizationRequestDcApi(
   request: Openid4vpAuthorizationRequest | Openid4vpAuthorizationRequestDcApi | JarAuthorizationRequest
 ): request is Openid4vpAuthorizationRequestDcApi {
-  return (
-    request.response_mode !== undefined &&
-    zOpenid4vpResponseModeDcApi.options.includes(
-      request.response_mode as Openid4vpAuthorizationRequestDcApi['response_mode']
-    )
-  )
+  return isOpenid4vpResponseModeDcApi(request.response_mode)
 }

--- a/packages/openid4vp/src/authorization-request/z-authorization-request.ts
+++ b/packages/openid4vp/src/authorization-request/z-authorization-request.ts
@@ -29,7 +29,7 @@ export const zOpenid4vpAuthorizationRequest = z
     client_metadata_uri: zHttpsUrl.optional(),
     state: z.string().optional(),
     transaction_data: z.array(z.string().base64url()).optional(),
-    trust_chain: z.unknown().optional(),
+    trust_chain: z.array(z.string()).nonempty().optional(),
     client_id_scheme: z
       .enum([
         'pre-registered',

--- a/packages/openid4vp/src/authorization-response/parse-authorization-response.ts
+++ b/packages/openid4vp/src/authorization-response/parse-authorization-response.ts
@@ -38,7 +38,9 @@ export async function parseOpenid4vpAuthorizationResponse(
 
   const expectedClientId = getOpenid4vpClientId({
     origin,
-    authorizationRequestPayload,
+    responseMode: authorizationRequestPayload.response_mode,
+    clientId: authorizationRequestPayload.client_id,
+    legacyClientIdScheme: authorizationRequestPayload.client_id_scheme,
   })
   if (authorizationResponse.response) {
     return parseJarmAuthorizationResponse({

--- a/packages/openid4vp/src/client-identifier-scheme/parse-client-identifier-scheme.ts
+++ b/packages/openid4vp/src/client-identifier-scheme/parse-client-identifier-scheme.ts
@@ -188,6 +188,21 @@ export function parseClientIdentifier(
       )
     }
 
+    if (!jar) {
+      throw new Oauth2ServerErrorResponseError({
+        error: Oauth2ErrorCodes.InvalidRequest,
+        error_description: 'Using client identifier scheme "https" requires a signed JAR request.',
+      })
+    }
+
+    if (jar.signer.method !== 'federation') {
+      throw new Oauth2ServerErrorResponseError({
+        error: Oauth2ErrorCodes.InvalidRequest,
+        error_description:
+          'Something went wrong. The JWT signer method is not federation but the client identifier scheme is https.',
+      })
+    }
+
     return {
       scheme,
       identifier: clientId,
@@ -226,6 +241,14 @@ export function parseClientIdentifier(
       throw new Oauth2ServerErrorResponseError({
         error: Oauth2ErrorCodes.InvalidRequest,
         error_description: 'Using client identifier scheme "did" requires a signed JAR request.',
+      })
+    }
+
+    if (jar.signer.method !== 'did') {
+      throw new Oauth2ServerErrorResponseError({
+        error: Oauth2ErrorCodes.InvalidRequest,
+        error_description:
+          'Something went wrong. The JWT signer method is not did but the client identifier scheme is did.',
       })
     }
 

--- a/packages/openid4vp/tests/parse-client-identifier-scheme.test.ts
+++ b/packages/openid4vp/tests/parse-client-identifier-scheme.test.ts
@@ -5,6 +5,15 @@ describe('Correctly parses the client identifier', () => {
   describe('legacy client_id_scheme', () => {
     test(`correctly handles legacy client_id_schme 'entity_id'`, () => {
       const client = parseClientIdentifier({
+        jar: {
+          signer: {
+            method: 'federation',
+            alg: '',
+            kid: '',
+            // @ts-ignore
+            publicJwk: {},
+          },
+        },
         authorizationRequestPayload: {
           response_mode: 'direct_post',
           client_id: 'https://example.com',
@@ -25,8 +34,13 @@ describe('Correctly parses the client identifier', () => {
 
     test(`correctly handles legacy client_id_schme 'did'`, () => {
       const client = parseClientIdentifier({
-        // @ts-expect-error
-        jar: { signer: { publicJwk: { kid: 'did:example:123#key-1' } } },
+        jar: {
+          signer: {
+            method: 'did',
+            // @ts-expect-error
+            publicJwk: { kid: 'did:example:123#key-1' },
+          },
+        },
         authorizationRequestPayload: {
           response_mode: 'direct_post',
           client_id: 'did:example:123#key-1',
@@ -133,6 +147,15 @@ describe('Correctly parses the client identifier', () => {
   describe('client_id_scheme', () => {
     test(`correctly handles client_id_schme 'entity_id'`, () => {
       const client = parseClientIdentifier({
+        jar: {
+          signer: {
+            method: 'federation',
+            kid: '',
+            alg: '',
+            // @ts-ignore
+            publicJwk: {},
+          },
+        },
         authorizationRequestPayload: {
           response_mode: 'direct_post',
           client_id: 'https://example.com',
@@ -152,8 +175,15 @@ describe('Correctly parses the client identifier', () => {
 
     test(`correctly handles client_id_schme 'did'`, () => {
       const client = parseClientIdentifier({
-        // @ts-expect-error
-        jar: { signer: { publicJwk: { kid: 'did:example:123#key-1' } } },
+        jar: {
+          signer: {
+            method: 'did',
+            // @ts-expect-error
+            publicJwk: {
+              kid: 'did:example:123#key-1',
+            },
+          },
+        },
         authorizationRequestPayload: {
           response_mode: 'direct_post',
           client_id: 'did:example:123#key-1',

--- a/packages/openid4vp/tests/parse-client-identifier-scheme.test.ts
+++ b/packages/openid4vp/tests/parse-client-identifier-scheme.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from 'vitest'
-import { parseClientIdentifier } from '../src/client-identifier-scheme/parse-client-identifier-scheme'
+import { validateOpenid4vpClientId } from '../src/client-identifier-scheme/parse-client-identifier-scheme'
 
 describe('Correctly parses the client identifier', () => {
   describe('legacy client_id_scheme', () => {
     test(`correctly handles legacy client_id_schme 'entity_id'`, () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         jar: {
           signer: {
             method: 'federation',
@@ -33,7 +33,7 @@ describe('Correctly parses the client identifier', () => {
     })
 
     test(`correctly handles legacy client_id_schme 'did'`, () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         jar: {
           signer: {
             method: 'did',
@@ -59,7 +59,7 @@ describe('Correctly parses the client identifier', () => {
     })
 
     test(`correctly handles legacy client_id_schme 'x509_san_dns'`, () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         // @ts-expect-error
         jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
         authorizationRequestPayload: {
@@ -83,7 +83,7 @@ describe('Correctly parses the client identifier', () => {
     })
 
     test(`correctly handles legacy client_id_schme 'x509_san_uri'`, () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         // @ts-expect-error
         jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
         authorizationRequestPayload: {
@@ -107,7 +107,7 @@ describe('Correctly parses the client identifier', () => {
     })
 
     test('correctly assumes no client_id_scheme as pre-registered', () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         authorizationRequestPayload: {
           response_mode: 'direct_post',
           client_id: 'pre-registered client',
@@ -125,7 +125,7 @@ describe('Correctly parses the client identifier', () => {
     })
 
     test('correctly applies pre-registered', () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         authorizationRequestPayload: {
           response_mode: 'direct_post',
           client_id: 'pre-registered client',
@@ -146,7 +146,7 @@ describe('Correctly parses the client identifier', () => {
 
   describe('client_id_scheme', () => {
     test(`correctly handles client_id_schme 'entity_id'`, () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         jar: {
           signer: {
             method: 'federation',
@@ -174,7 +174,7 @@ describe('Correctly parses the client identifier', () => {
     })
 
     test(`correctly handles client_id_schme 'did'`, () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         jar: {
           signer: {
             method: 'did',
@@ -201,7 +201,7 @@ describe('Correctly parses the client identifier', () => {
     })
 
     test(`correctly handles client_id_schme 'x509_san_dns'`, () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         // @ts-expect-error
         jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
         authorizationRequestPayload: {
@@ -224,7 +224,7 @@ describe('Correctly parses the client identifier', () => {
     })
 
     test(`correctly handles legacy client_id_schme 'x509_san_uri'`, () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         // @ts-expect-error
         jar: { signer: { method: 'x5c', x5c: ['certificate'] } },
         authorizationRequestPayload: {
@@ -247,7 +247,7 @@ describe('Correctly parses the client identifier', () => {
     })
 
     test('correctly assumes no client_id_scheme as pre-registered', () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         authorizationRequestPayload: {
           response_mode: 'direct_post',
           client_id: 'pre-registered client',
@@ -265,10 +265,10 @@ describe('Correctly parses the client identifier', () => {
     })
 
     test('correctly applies pre-registered', () => {
-      const client = parseClientIdentifier({
+      const client = validateOpenid4vpClientId({
         authorizationRequestPayload: {
           response_mode: 'direct_post',
-          client_id: 'pre-registered:pre-registered client',
+          client_id: 'pre-registered client',
           nonce: 'nonce',
           response_type: 'vp_token',
         },
@@ -277,7 +277,7 @@ describe('Correctly parses the client identifier', () => {
 
       expect(client).toMatchObject({
         identifier: 'pre-registered client',
-        originalValue: 'pre-registered:pre-registered client',
+        originalValue: 'pre-registered client',
         scheme: 'pre-registered',
       })
     })


### PR DESCRIPTION
- rename `trustChain` to `federation`
- add allowed signer methods to jwt to jwt signer, to prevent some confusion attacks with jwts containing mulitple test signing methods.
- make client id parsing logic (including legacy client id scheme) reusable, this way we can use it in other places where we need it