### PR TITLE
chore: add response zod error

### DIFF
--- a/packages/openid4vci/src/error/Openid4vciRetrieveCredentialsError.ts
+++ b/packages/openid4vci/src/error/Openid4vciRetrieveCredentialsError.ts
@@ -1,3 +1,4 @@
+import { formatZodError } from '@openid4vc/utils'
 import type { RetrieveCredentialsResponseNotOk } from '../credential-request/retrieve-credentials'
 import { Openid4vciError } from './Openid4vciError'
 
@@ -7,8 +8,14 @@ export class Openid4vciRetrieveCredentialsError extends Openid4vciError {
     public response: RetrieveCredentialsResponseNotOk,
     responseText: string
   ) {
-    super(
-      `${message}\n${JSON.stringify(response.credentialResponseResult?.data ?? response.credentialErrorResponseResult?.data ?? responseText, null, 2)}`
-    )
+    const errorData =
+      response.credentialResponseResult?.data ??
+      response.credentialErrorResponseResult?.data ??
+      (response.credentialResponseResult?.error
+        ? formatZodError(response.credentialResponseResult.error)
+        : undefined) ??
+      responseText
+
+    super(`${message}\n${JSON.stringify(errorData, null, 2)}`)
   }
 }


### PR DESCRIPTION
Adds zod error to the error message, as there would be the case where we receive an invalid response, and the zod error would not be shown.

