### PR TITLE
feat(oauth2): add grant_types_supported server metadata

### DIFF
--- a/.changeset/evil-forks-cut.md
+++ b/.changeset/evil-forks-cut.md
@@ -1,0 +1,5 @@
+---
+"@openid4vc/oauth2": patch
+---
+
+Add grant_types_supported to the authorization server metadata.

--- a/packages/oauth2/src/metadata/authorization-server/z-authorization-server-metadata.ts
+++ b/packages/oauth2/src/metadata/authorization-server/z-authorization-server-metadata.ts
@@ -17,6 +17,7 @@ export const zAuthorizationServerMetadata = z
     token_endpoint_auth_methods_supported: z.optional(z.array(z.union([knownClientAuthenticationMethod, z.string()]))),
     authorization_endpoint: z.optional(zHttpsUrl),
     jwks_uri: z.optional(zHttpsUrl),
+    grant_types_supported: z.optional(z.array(z.string())),
 
     // RFC7636
     code_challenge_methods_supported: z.optional(z.array(z.string())),


### PR DESCRIPTION
Adds `grant_types_supported` field to the server metadata: https://datatracker.ietf.org/doc/html/rfc8414#section-2

The idea is that there might be a specific server for `refresh_token`, so I'd like to check it just in case.