### PR TITLE
fix(openid4vci): re-add passthrough on original zod type

### DIFF
--- a/.changeset/olive-oil-face.md
+++ b/.changeset/olive-oil-face.md
@@ -1,0 +1,5 @@
+---
+"@openid4vc/openid4vp": patch
+---
+
+Retain the `.passthrough()` in the Zod common credential configuration's for correct typing.

--- a/packages/openid4vci/src/formats/credential/sd-jwt-vc/z-sd-jwt-vc.ts
+++ b/packages/openid4vci/src/formats/credential/sd-jwt-vc/z-sd-jwt-vc.ts
@@ -30,7 +30,7 @@ export const zSdJwtVcCredentialIssuerMetadataDraft14 = zCredentialConfigurationS
   order: z.optional(z.array(z.string())),
 })
 
-export const zSdJwtVcCredentialRequestFormatDraft14 = zCredentialConfigurationSupportedCommonDraft15.extend({
+export const zSdJwtVcCredentialRequestFormatDraft14 = z.object({
   format: zSdJwtVcFormatIdentifier,
   vct: z.string(),
   claims: z.optional(zCredentialConfigurationSupportedClaimsDraft14),

--- a/packages/openid4vci/src/metadata/credential-issuer/z-credential-configuration-supported-common.ts
+++ b/packages/openid4vci/src/metadata/credential-issuer/z-credential-configuration-supported-common.ts
@@ -30,54 +30,58 @@ export const zCredentialConfigurationSupportedCommonCredentialMetadata = z.objec
   display: z.array(zCredentialConfigurationSupportedDisplayEntry).optional(),
 })
 
-export const zCredentialConfigurationSupportedCommon = z.object({
-  format: z.string(),
-  scope: z.string().optional(),
-  cryptographic_binding_methods_supported: z.array(z.string()).optional(),
-  credential_signing_alg_values_supported: z.array(z.string()).or(z.array(z.number())).optional(),
-  proof_types_supported: z
-    .record(
-      z.union([z.literal('jwt'), z.literal('attestation'), z.string()]),
-      z.object({
-        proof_signing_alg_values_supported: z.array(z.string()),
-        key_attestations_required: z
-          .object({
-            key_storage: zIso18045OrStringArray.optional(),
-            user_authentication: zIso18045OrStringArray.optional(),
-          })
-          .passthrough()
-          .optional(),
-      })
-    )
-    .optional(),
-  credential_metadata: zCredentialConfigurationSupportedCommonCredentialMetadata.optional(),
+export const zCredentialConfigurationSupportedCommon = z
+  .object({
+    format: z.string(),
+    scope: z.string().optional(),
+    cryptographic_binding_methods_supported: z.array(z.string()).optional(),
+    credential_signing_alg_values_supported: z.array(z.string()).or(z.array(z.number())).optional(),
+    proof_types_supported: z
+      .record(
+        z.union([z.literal('jwt'), z.literal('attestation'), z.string()]),
+        z.object({
+          proof_signing_alg_values_supported: z.array(z.string()),
+          key_attestations_required: z
+            .object({
+              key_storage: zIso18045OrStringArray.optional(),
+              user_authentication: zIso18045OrStringArray.optional(),
+            })
+            .passthrough()
+            .optional(),
+        })
+      )
+      .optional(),
+    credential_metadata: zCredentialConfigurationSupportedCommonCredentialMetadata.optional(),
 
-  // For typing purposes. Can be removed once we drop support for draft <= 15.
-  claims: z.optional(z.never()),
-})
+    // For typing purposes. Can be removed once we drop support for draft <= 15.
+    claims: z.optional(z.never()),
+  })
+  .passthrough()
 
-export const zCredentialConfigurationSupportedCommonDraft15 = z.object({
-  format: z.string(),
-  scope: z.string().optional(),
-  cryptographic_binding_methods_supported: z.array(z.string()).optional(),
-  credential_signing_alg_values_supported: z.array(z.string()).or(z.array(z.number())).optional(),
-  proof_types_supported: z
-    .record(
-      z.union([z.literal('jwt'), z.literal('attestation'), z.string()]),
-      z.object({
-        proof_signing_alg_values_supported: z.array(z.string()),
-        key_attestations_required: z
-          .object({
-            key_storage: zIso18045OrStringArray.optional(),
-            user_authentication: zIso18045OrStringArray.optional(),
-          })
-          .passthrough()
-          .optional(),
-      })
-    )
-    .optional(),
-  display: z.array(zCredentialConfigurationSupportedDisplayEntry).optional(),
+export const zCredentialConfigurationSupportedCommonDraft15 = z
+  .object({
+    format: z.string(),
+    scope: z.string().optional(),
+    cryptographic_binding_methods_supported: z.array(z.string()).optional(),
+    credential_signing_alg_values_supported: z.array(z.string()).or(z.array(z.number())).optional(),
+    proof_types_supported: z
+      .record(
+        z.union([z.literal('jwt'), z.literal('attestation'), z.string()]),
+        z.object({
+          proof_signing_alg_values_supported: z.array(z.string()),
+          key_attestations_required: z
+            .object({
+              key_storage: zIso18045OrStringArray.optional(),
+              user_authentication: zIso18045OrStringArray.optional(),
+            })
+            .passthrough()
+            .optional(),
+        })
+      )
+      .optional(),
+    display: z.array(zCredentialConfigurationSupportedDisplayEntry).optional(),
 
-  // For typing purposes.
-  credential_metadata: z.optional(z.never()),
-})
+    // For typing purposes.
+    credential_metadata: z.optional(z.never()),
+  })
+  .passthrough()

--- a/packages/openid4vci/src/metadata/credential-issuer/z-credential-issuer-metadata.ts
+++ b/packages/openid4vci/src/metadata/credential-issuer/z-credential-issuer-metadata.ts
@@ -60,10 +60,7 @@ export const allCredentialIssuerMetadataFormatIdentifiers = allCredentialIssuerM
 )
 
 export const zCredentialConfigurationSupportedWithFormats = z
-  .union([
-    zCredentialConfigurationSupportedCommon.passthrough(),
-    zCredentialConfigurationSupportedCommonDraft15.passthrough(),
-  ])
+  .union([zCredentialConfigurationSupportedCommon, zCredentialConfigurationSupportedCommonDraft15])
   .transform((data, ctx) => {
     // No additional validation for unknown formats
     if (!allCredentialIssuerMetadataFormatIdentifiers.includes(data.format as CredentialFormatIdentifier)) return data


### PR DESCRIPTION
Readds the `.passthrough()` on the correct place. This was causing some issues since `CredentialConfigurationSupportedWithFormats` could no longer be indexed.