### PR TITLE
fix(openid4vci): type of CredentialResponse.credentials

### DIFF
--- a/.changeset/twenty-grapes-turn.md
+++ b/.changeset/twenty-grapes-turn.md
@@ -1,0 +1,5 @@
+---
+"@openid4vc/openid4vci": patch
+---
+
+The field `credentials` on the types `CredentialResponse` and `DeferredCredentialResponse` has been updated to correctly reflect the object structure present from Draft 15 and onwards of the OpenID for Verifiable Credential Issuance specification.

--- a/packages/openid4vci/src/credential-request/credential-response.ts
+++ b/packages/openid4vci/src/credential-request/credential-response.ts
@@ -28,7 +28,7 @@ export interface CreateCredentialResponseOptions {
 }
 
 export function createCredentialResponse(options: CreateCredentialResponseOptions) {
-  const credentialResponse = parseWithErrorHandling(zCredentialResponse, {
+  return parseWithErrorHandling(zCredentialResponse, {
     c_nonce: options.cNonce,
     c_nonce_expires_in: options.cNonceExpiresInSeconds,
     credential: options.credential,
@@ -43,8 +43,6 @@ export function createCredentialResponse(options: CreateCredentialResponseOption
     format: options.credentialRequest.format?.format,
     ...options.additionalPayload,
   } satisfies CredentialResponse)
-
-  return credentialResponse
 }
 
 export type CreateDeferredCredentialResponseOptions = {

--- a/packages/openid4vci/src/credential-request/z-credential-response.ts
+++ b/packages/openid4vci/src/credential-request/z-credential-response.ts
@@ -5,7 +5,14 @@ const zCredentialEncoding = z.union([z.string(), z.record(z.string(), z.any())])
 
 const zBaseCredentialResponse = z
   .object({
-    credentials: z.optional(z.array(zCredentialEncoding)),
+    credentials: z
+      .union([
+        // Draft >= 15
+        z.array(z.object({ credential: zCredentialEncoding })),
+        // Draft < 15
+        z.array(zCredentialEncoding),
+      ])
+      .optional(),
     interval: z.number().int().positive().optional(),
     notification_id: z.string().optional(),
   })


### PR DESCRIPTION
Fixes #95.

To keep backward compatibility, I added the new type as a `union`, so `credentials` can assume both types.

The user of the library has to choose which format to use based on the draft they support. This already happens with some other fields, like the singular `credential`. This also means that when parsing a credential request, the output is **not** normalized to the latest version (just like the current behaviour), but it can be any of the two (old and new).