### PR TITLE
feat: add support for id tokens

### DIFF
--- a/.changeset/puny-ravens-cheer.md
+++ b/.changeset/puny-ravens-cheer.md
@@ -1,0 +1,7 @@
+---
+"@openid4vc/oauth2": patch
+---
+
+Add support for parsing and verifying an ID Token JWT according to the OpenID Connect specification.
+
+Exports some other utilities.

--- a/packages/oauth2/src/common/jwt/z-jwt.ts
+++ b/packages/oauth2/src/common/jwt/z-jwt.ts
@@ -105,6 +105,7 @@ export const zJwtPayload = z
     nbf: zInteger.optional(),
     nonce: z.string().optional(),
     jti: z.string().optional(),
+    sub: z.string().optional(),
 
     cnf: zJwtConfirmationPayload.optional(),
 

--- a/packages/oauth2/src/id-token/index.ts
+++ b/packages/oauth2/src/id-token/index.ts
@@ -1,0 +1,2 @@
+export * from './verify-id-token'
+export * from './z-id-token-jwt'

--- a/packages/oauth2/src/id-token/verify-id-token.ts
+++ b/packages/oauth2/src/id-token/verify-id-token.ts
@@ -1,0 +1,93 @@
+import type { CallbackContext } from '../callbacks'
+import { extractJwkFromJwksForJwt } from '../common/jwk/jwks'
+import { decodeJwt } from '../common/jwt/decode-jwt'
+import { verifyJwt } from '../common/jwt/verify-jwt'
+import { Oauth2Error } from '../error/Oauth2Error'
+import type { AuthorizationServerMetadata } from '../metadata/authorization-server/z-authorization-server-metadata'
+import { fetchJwks } from '../metadata/fetch-jwks-uri'
+import { zIdTokenJwtHeader, zIdTokenJwtPayload } from './z-id-token-jwt'
+
+export interface VerifyJwtIdTokenOptions {
+  /**
+   * The compact id token.
+   */
+  idToken: string
+
+  /**
+   * Callbacks used for verifying the id token
+   */
+  callbacks: Pick<CallbackContext, 'verifyJwt' | 'fetch'>
+
+  /**
+   * If not provided current time will be used
+   */
+  now?: Date
+
+  /**
+   * Authorization server metadata
+   */
+  authorizationServer: AuthorizationServerMetadata
+
+  /**
+   * The client_id of the Relying Party for which the token was issued.
+   */
+  clientId: string
+
+  /**
+   * Expected nonce in the payload. If not provided the nonce won't be validated.
+   */
+  expectedNonce?: string
+}
+
+/**
+ * Verify an ID Token JWT.
+ */
+export async function verifyJwtIdToken(options: VerifyJwtIdTokenOptions) {
+  const { header, payload } = decodeJwt({
+    jwt: options.idToken,
+    headerSchema: zIdTokenJwtHeader,
+    payloadSchema: zIdTokenJwtPayload,
+  })
+
+  const jwksUrl = options.authorizationServer.jwks_uri
+  if (!jwksUrl) {
+    throw new Oauth2Error(
+      `Authorization server '${options.authorizationServer.issuer}' does not have a 'jwks_uri' parameter to fetch JWKs.`
+    )
+  }
+
+  if (payload.iss !== options.authorizationServer.issuer) {
+    throw new Oauth2Error(
+      `Invalid 'iss' claim in id token jwt. Expected '${options.authorizationServer.issuer}', got '${payload.iss}'.`
+    )
+  }
+
+  if (payload.azp && payload.azp !== options.clientId) {
+    throw new Oauth2Error(`Invalid 'azp' claim in id token jwt. Expected '${options.clientId}', got '${payload.azp}'.`)
+  }
+
+  const jwks = await fetchJwks(jwksUrl, options.callbacks.fetch)
+  const publicJwk = extractJwkFromJwksForJwt({
+    kid: header.kid,
+    jwks,
+    use: 'sig',
+  })
+
+  await verifyJwt({
+    compact: options.idToken,
+    header,
+    payload,
+    signer: { method: 'jwk', publicJwk, alg: header.alg },
+    verifyJwtCallback: options.callbacks.verifyJwt,
+    errorMessage: 'Error during verification of id token jwt.',
+    now: options.now,
+    expectedAudience: options.clientId,
+    expectedIssuer: options.authorizationServer.issuer,
+    expectedNonce: options.expectedNonce,
+  })
+
+  return {
+    header,
+    payload,
+  }
+}

--- a/packages/oauth2/src/id-token/z-id-token-jwt.ts
+++ b/packages/oauth2/src/id-token/z-id-token-jwt.ts
@@ -1,0 +1,59 @@
+import { zInteger } from '@openid4vc/utils'
+import z from 'zod'
+import { zJwtHeader, zJwtPayload } from '../common/jwt/z-jwt'
+
+export const zIdTokenJwtHeader = z
+  .object({
+    ...zJwtHeader.shape,
+  })
+  .loose()
+export type IdTokenJwtHeader = z.infer<typeof zIdTokenJwtHeader>
+
+export const zIdTokenJwtPayload = z
+  .object({
+    ...zJwtPayload.shape,
+    iss: z.string(),
+    sub: z.string(),
+    aud: z.string(),
+    exp: zInteger,
+    iat: zInteger,
+    auth_time: zInteger.optional(),
+    acr: z.string().optional(),
+    amr: z.array(z.string()).optional(),
+    azp: z.string().optional(),
+
+    // Standard Profile Claims
+    // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+    name: z.string().optional(),
+    given_name: z.string().optional(),
+    family_name: z.string().optional(),
+    middle_name: z.string().optional(),
+    nickname: z.string().optional(),
+    preferred_username: z.string().optional(),
+    profile: z.url().optional(),
+    picture: z.url().optional(),
+    website: z.url().optional(),
+    email: z.email().optional(),
+    email_verified: z.boolean().optional(),
+    gender: z.enum(['male', 'female']).or(z.string()).optional(),
+    birthdate: z.iso.date().optional(),
+    zoneinfo: z.string().optional(),
+    locale: z.string().optional(),
+    phone_number: z.string().optional(),
+    phone_number_verified: z.boolean().optional(),
+    address: z
+      .object({
+        formatted: z.string().optional(),
+        street_address: z.string().optional(),
+        locality: z.string().optional(),
+        region: z.string().optional(),
+        postal_code: z.string().optional(),
+        country: z.string().optional(),
+      })
+      .loose()
+      .optional(),
+    updated_at: zInteger.optional(),
+  })
+  .loose()
+
+export type IdTokenJwtPayload = z.infer<typeof zIdTokenJwtPayload>

--- a/packages/oauth2/src/index.ts
+++ b/packages/oauth2/src/index.ts
@@ -58,6 +58,8 @@ export { HashAlgorithm } from './callbacks'
 export {
   type CreateClientAttestationJwtOptions,
   createClientAttestationJwt,
+  VerifiedClientAttestationJwt,
+  verifyClientAttestationJwt,
 } from './client-attestation/client-attestation'
 export type { RequestClientAttestationOptions } from './client-attestation/client-attestation-pop'
 export type {
@@ -108,7 +110,7 @@ export {
   zJwtHeader,
   zJwtPayload,
 } from './common/jwt/z-jwt'
-export { zAlgValueNotNone } from './common/z-common'
+export { type RequestLike, zAlgValueNotNone } from './common/z-common'
 export {
   Oauth2ErrorCodes,
   type Oauth2ErrorResponse,
@@ -125,6 +127,7 @@ export {
   type WwwAuthenticateHeaderChallenge,
 } from './error/Oauth2ResourceUnauthorizedError'
 export { Oauth2ServerErrorResponseError } from './error/Oauth2ServerErrorResponseError'
+export * from './id-token'
 export {
   fetchAuthorizationServerMetadata,
   getAuthorizationServerMetadataFromList,


### PR DESCRIPTION
Adds support for ID Tokens, as per defined in the OpenID Connect specification. I also exported some other things that I noticed we wanted in Credo.