### PR TITLE
fix: type file reference

### DIFF
--- a/packages/oauth2/package.json
+++ b/packages/oauth2/package.json
@@ -15,12 +15,12 @@
   "publishConfig": {
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
-    "types": "./dist/index.d.ts",
+    "types": "./dist/index.d.mts",
     "exports": {
       ".": {
         "import": "./dist/index.mjs",
         "require": "./dist/index.cjs",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.mts"
       },
       "./package.json": "./package.json"
     }

--- a/packages/openid4vci/package.json
+++ b/packages/openid4vci/package.json
@@ -15,12 +15,12 @@
   "publishConfig": {
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
-    "types": "./dist/index.d.ts",
+    "types": "./dist/index.d.mts",
     "exports": {
       ".": {
         "import": "./dist/index.mjs",
         "require": "./dist/index.cjs",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.mts"
       },
       "./package.json": "./package.json"
     }

--- a/packages/openid4vp/package.json
+++ b/packages/openid4vp/package.json
@@ -15,12 +15,12 @@
   "publishConfig": {
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
-    "types": "./dist/index.d.ts",
+    "types": "./dist/index.d.mts",
     "exports": {
       ".": {
         "import": "./dist/index.mjs",
         "require": "./dist/index.cjs",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.mts"
       },
       "./package.json": "./package.json"
     }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,12 +15,12 @@
   "publishConfig": {
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
-    "types": "./dist/index.d.ts",
+    "types": "./dist/index.d.mts",
     "exports": {
       ".": {
         "import": "./dist/index.mjs",
         "require": "./dist/index.cjs",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.mts"
       },
       "./package.json": "./package.json"
     }


### PR DESCRIPTION
There are two identical type files generated, but both of them have a new ending. Therefore we need to update the reference in the package.json form `.d.ts` to `.d.mts`

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>