### PR TITLE
fix: allow both credential and credentials to be present in credential response

### DIFF
--- a/.changeset/lemon-ears-cross.md
+++ b/.changeset/lemon-ears-cross.md
@@ -1,0 +1,5 @@
+---
+"@openid4vc/openid4vci": patch
+---
+
+fix: allow both credential and credentials to be present in credential response. This enables integration with issuers that return both for backwards compatibility

--- a/packages/openid4vci/src/credential-request/z-credential-response.ts
+++ b/packages/openid4vci/src/credential-request/z-credential-response.ts
@@ -31,10 +31,12 @@ export const zCredentialResponse = zBaseCredentialResponse
   .superRefine((value, ctx) => {
     const { credential, credentials, transaction_id, interval, notification_id } = value
 
-    if ([credential, credentials, transaction_id].filter((i) => i !== undefined).length !== 1) {
+    // NOTE: we allow both credential and credentials to be present, to better work with
+    // issuers that return both for backwards compatibility
+    if ([credential || credentials, transaction_id].filter((i) => i !== undefined).length !== 1) {
       ctx.addIssue({
         code: 'custom',
-        message: `Exactly one of 'credential', 'credentials', or 'transaction_id' MUST be defined.`,
+        message: `Exactly one of 'credential'/'credentials', or 'transaction_id' MUST be defined.`,
       })
     }
 


### PR DESCRIPTION
This enables integration with issuers that return both for backwards compatibility

This was an issue when testing our wallet with the EduWallets pilot issuer, see https://github.com/eduwallet-pilots/interop/issues/8