### PR TITLE
fix: remove client_attestation_pop_nonce_required

### DIFF
--- a/packages/oauth2/src/metadata/authorization-server/z-authorization-server-metadata.ts
+++ b/packages/oauth2/src/metadata/authorization-server/z-authorization-server-metadata.ts
@@ -46,9 +46,6 @@ export const zAuthorizationServerMetadata = z
     // From OpenID4VCI specification
     'pre-authorized_grant_anonymous_access_supported': z.optional(z.boolean()),
 
-    // Attestation Based Client Auth (draft 5)
-    client_attestation_pop_nonce_required: z.boolean().optional(),
-
     // RFC9207
     authorization_response_iss_parameter_supported: z.boolean().optional(),
   })


### PR DESCRIPTION
Removing client_attestation_pop_nonce_required since it got removed in the latest draft of the attestation spec

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>