### PR TITLE
fix(openid4vci): source credential response encryption alg from the JWK

### DIFF
--- a/.changeset/tame-otters-wander.md
+++ b/.changeset/tame-otters-wander.md
@@ -1,0 +1,7 @@
+---
+"@openid4vc/openid4vci": patch
+---
+
+fix: source credential response encryption `alg` from the JWK
+
+`credential_response_encryption` no longer requires a top-level `alg` (per OpenID4VCI V1 the key management algorithm is carried in `jwk.alg`), so parsing no longer fails when it is absent. The optional `zip` parameter was added. The response encryptor now sources `alg` from `jwk.alg`, falling back to a top-level `alg` for backwards compatibility with draft 14/15 wallets (where it was a required member).

--- a/packages/openid4vci/src/credential-request/credential-response.ts
+++ b/packages/openid4vci/src/credential-request/credential-response.ts
@@ -10,6 +10,31 @@ import {
   zDeferredCredentialResponse,
 } from './z-credential-response'
 
+/**
+ * Builds the JWE encryptor for credential response encryption.
+ *
+ * Per OpenID4VCI V1 the key management `alg` is carried inside the `jwk`
+ * (`credential_response_encryption.jwk.alg`), not as a sibling of `jwk`. For backwards compatibility
+ * with draft 14/15 wallets, which send `alg` as a required top-level member, we fall back to it.
+ */
+function getCredentialResponseJweEncryptor(credentialResponseEncryption: CredentialResponseEncryption): JweEncryptor {
+  const { jwk, enc } = credentialResponseEncryption
+  const alg = jwk.alg ?? credentialResponseEncryption.alg
+
+  if (!alg) {
+    throw new Openid4vciError(
+      `Unable to encrypt the credential response. The 'jwk' in 'credential_response_encryption' is missing the required 'alg' parameter.`
+    )
+  }
+
+  return {
+    method: 'jwk',
+    publicJwk: jwk,
+    alg,
+    enc,
+  }
+}
+
 export interface CreateCredentialResponseOptions {
   credentialRequest: ParseCredentialRequestReturn
 
@@ -86,12 +111,7 @@ export async function createCredentialResponse(
       )
     }
 
-    const jweEncryptor: JweEncryptor = {
-      method: 'jwk',
-      publicJwk: options.credentialResponseEncryption.jwk,
-      alg: options.credentialResponseEncryption.alg,
-      enc: options.credentialResponseEncryption.enc,
-    }
+    const jweEncryptor = getCredentialResponseJweEncryptor(options.credentialResponseEncryption)
 
     const { jwe } = await options.callbacks.encryptJwe(jweEncryptor, JSON.stringify(credentialResponse))
 
@@ -181,12 +201,7 @@ export async function createDeferredCredentialResponse(
       )
     }
 
-    const jweEncryptor: JweEncryptor = {
-      method: 'jwk',
-      publicJwk: options.credentialResponseEncryption.jwk,
-      alg: options.credentialResponseEncryption.alg,
-      enc: options.credentialResponseEncryption.enc,
-    }
+    const jweEncryptor = getCredentialResponseJweEncryptor(options.credentialResponseEncryption)
 
     const { jwe } = await options.callbacks.encryptJwe(jweEncryptor, JSON.stringify(deferredCredentialResponse))
 

--- a/packages/openid4vci/src/credential-request/z-credential-request-common.ts
+++ b/packages/openid4vci/src/credential-request/z-credential-request-common.ts
@@ -42,8 +42,12 @@ export type CredentialRequestProofs = z.infer<typeof zCredentialRequestProofs>
 export const zCredentialResponseEncryption = z
   .object({
     jwk: zJwk,
-    alg: z.string(),
+    // `alg` is no longer required: per OpenID4VCI V1 the key management algorithm is carried in the
+    // `jwk`. It is kept as an optional sibling for backwards compatibility with draft 14/15, where it
+    // was a required top-level member.
+    alg: z.optional(z.string()),
     enc: z.string(),
+    zip: z.optional(z.string()),
   })
   .loose()
 

--- a/packages/openid4vci/tests/credential-response-encryption.test.ts
+++ b/packages/openid4vci/tests/credential-response-encryption.test.ts
@@ -1,0 +1,83 @@
+import type { JweEncryptor } from '@openid4vc/oauth2'
+import { describe, expect, test } from 'vitest'
+import { createCredentialResponse } from '../src/credential-request/credential-response'
+import { zCredentialResponseEncryption } from '../src/credential-request/z-credential-request-common'
+
+const jwkWithAlg = { kty: 'EC', crv: 'P-256', x: 'x', y: 'y', alg: 'ECDH-ES' }
+const jwkWithoutAlg = { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' }
+
+function captureEncryptor() {
+  const captured: { encryptor?: JweEncryptor } = {}
+  return {
+    captured,
+    callbacks: {
+      encryptJwe: async (encryptor: JweEncryptor) => {
+        captured.encryptor = encryptor
+        return { encryptionJwk: encryptor.publicJwk, jwe: 'JWE' }
+      },
+    },
+  }
+}
+
+const baseOptions = {
+  // Minimal request stub: createCredentialResponse only reads `credentialRequest.format?.format`.
+  credentialRequest: {} as never,
+  credential: 'credential-jwt',
+}
+
+describe('credential_response_encryption', () => {
+  describe('schema', () => {
+    test('parses without a top-level `alg` (it lives in the jwk)', () => {
+      const result = zCredentialResponseEncryption.safeParse({ jwk: jwkWithAlg, enc: 'A128GCM' })
+      expect(result.success).toBe(true)
+    })
+
+    test('accepts the optional `zip` parameter', () => {
+      const parsed = zCredentialResponseEncryption.parse({ jwk: jwkWithAlg, enc: 'A128GCM', zip: 'DEF' })
+      expect(parsed.zip).toBe('DEF')
+    })
+
+    test('still accepts a top-level `alg` (draft 14/15 wallets)', () => {
+      const parsed = zCredentialResponseEncryption.parse({ jwk: jwkWithoutAlg, alg: 'ECDH-ES', enc: 'A128GCM' })
+      expect(parsed.alg).toBe('ECDH-ES')
+    })
+  })
+
+  describe('createCredentialResponse encryption', () => {
+    test('sources `alg` from the jwk', async () => {
+      const { captured, callbacks } = captureEncryptor()
+      const { credentialResponseJwt } = await createCredentialResponse({
+        ...baseOptions,
+        credentialResponseEncryption: { jwk: jwkWithAlg, enc: 'A128GCM' },
+        callbacks,
+      })
+
+      expect(credentialResponseJwt).toBe('JWE')
+      expect(captured.encryptor?.alg).toBe('ECDH-ES')
+      expect(captured.encryptor?.enc).toBe('A128GCM')
+      expect(captured.encryptor?.publicJwk).toEqual(jwkWithAlg)
+    })
+
+    test('falls back to a sibling `alg` when the jwk has none', async () => {
+      const { captured, callbacks } = captureEncryptor()
+      await createCredentialResponse({
+        ...baseOptions,
+        credentialResponseEncryption: { jwk: jwkWithoutAlg, alg: 'ECDH-ES', enc: 'A128GCM' },
+        callbacks,
+      })
+
+      expect(captured.encryptor?.alg).toBe('ECDH-ES')
+    })
+
+    test('throws when no `alg` is present in the jwk or as a sibling', async () => {
+      const { callbacks } = captureEncryptor()
+      await expect(
+        createCredentialResponse({
+          ...baseOptions,
+          credentialResponseEncryption: { jwk: jwkWithoutAlg, enc: 'A128GCM' },
+          callbacks,
+        })
+      ).rejects.toThrow(/missing the required 'alg'/)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #232.

`credential_response_encryption` required a top-level `alg`. Per OpenID4VCI **V1** the key management algorithm is carried inside the `jwk` (`jwk.alg`), so requiring a sibling `alg` made parsing fail for spec-correct V1 requests.

## Changes

- `zCredentialResponseEncryption`: `alg` is now **optional** (was required); added the optional `zip` parameter (V1).
- `credential-response.ts`: both encryptors source `alg` from `jwk.alg` via a shared `getCredentialResponseJweEncryptor` helper, with a clear error when no `alg` is found.

## Backwards compatibility

`alg` is kept as an **optional** member (rather than removed) and used as a fallback because draft 14 and draft 15 — both supported by this library (`version.ts`) — define `alg` as a **required top-level member** of `credential_response_encryption`, with the algorithm not in the `jwk`:

| version | shape | top-level `alg` | `zip` |
| --- | --- | --- | --- |
| Draft 14 (§7.2) | `{ jwk, alg, enc }` | required | no |
| Draft 15 | `{ jwk, alg, enc }` | required | no |
| V1 | `{ jwk, enc, zip }` | in `jwk` | yes |

So `jwk.alg ?? alg` lets one issuer serve draft 14/15 and V1 wallets. (Draft 18 is OID4VP, not OID4VCI, so it does not apply here.)

## Tests

New `credential-response-encryption.test.ts`: schema parsing with/without a top-level `alg`, `zip`, and the encryptor's jwk-sourcing / fallback / missing-`alg` error paths.
