### PR TITLE
fix: default aud value is static `https://self-issued.me/v2`

### DIFF
--- a/.changeset/thirty-icons-sip.md
+++ b/.changeset/thirty-icons-sip.md
@@ -1,0 +1,5 @@
+---
+"@openid4vc/openid4vp": patch
+---
+
+fix: signed openid4vp requests without an `aud` field set now set the `aud` field to 'https://self-issued.me/v2' according to OpenID4VP section 5.8

--- a/packages/openid4vp/src/authorization-request/create-authorization-request.ts
+++ b/packages/openid4vp/src/authorization-request/create-authorization-request.ts
@@ -106,7 +106,7 @@ export async function createOpenid4vpAuthorizationRequest(options: CreateOpenid4
 
   if (jar) {
     additionalJwtPayload = !jar.additionalJwtPayload?.aud
-      ? { ...jar.additionalJwtPayload, aud: jar.requestUri }
+      ? { ...jar.additionalJwtPayload, aud: 'https://self-issued.me/v2' }
       : jar.additionalJwtPayload
 
     const jarResult = await createJarAuthorizationRequest({


### PR DESCRIPTION
This came from a misunderstanding of the spec. We thought it must be the same as the OpenID4VP request `iss` value. But it must actually be set to the `issuer` value of the wallet. 

Which you only know if you did dynamic discovery. If so, you can set the `aud` value in the jar settings like before. This just changes the default to correctly use the static discovery (using `https://self-issued.me/v2` url)

See https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-5.8