### PR TITLE
Fix correct check for notification_id to match spec

### DIFF
--- a/.changeset/small-views-clean.md
+++ b/.changeset/small-views-clean.md
@@ -1,0 +1,5 @@
+---
+"@openid4vc/openid4vci": patch
+---
+
+Fix credential response check to match spec definition

--- a/packages/openid4vci/src/credential-request/z-credential-response.ts
+++ b/packages/openid4vci/src/credential-request/z-credential-response.ts
@@ -85,7 +85,7 @@ export const zDeferredCredentialResponse = zBaseCredentialResponse.superRefine((
     })
   }
 
-  if (notification_id && credentials) {
+  if (notification_id && !credentials) {
     ctx.addIssue({
       code: 'custom',
       message: `'notification_id' MUST NOT be defined when 'credentials' is not defined.`,


### PR DESCRIPTION
Fixes issue https://github.com/openwallet-foundation-labs/oid4vc-ts/issues/245 by changing the credential response check to reject only when credentials are not present and notification_id is present.