### PR TITLE
feat(oauth2): bring wallet attestations to draft 9

### DIFF
--- a/.changeset/wallet-attestation-draft-09.md
+++ b/.changeset/wallet-attestation-draft-09.md
@@ -1,0 +1,10 @@
+---
+"@openid4vc/oauth2": minor
+---
+
+Align wallet (client) attestation with draft 09 of OAuth 2.0 Attestation-Based Client Authentication.
+
+- Client Attestation and Client Attestation PoP JWTs no longer emit the `iss` claim (removed in draft 08). Verification still accepts legacy JWTs that include `iss`.
+- The Client Attestation PoP JWT uses the `challenge` claim (renamed from `nonce` in draft 06) and no longer includes `exp` (removed in draft 06). Verification accepts either `challenge` or the legacy `nonce`. The `nonce`/`expectedNonce` options are deprecated aliases for `challenge`/`expectedChallenge`.
+- Added authorization server metadata parameters `client_attestation_signing_alg_values_supported` and `client_attestation_pop_signing_alg_values_supported` (draft 07), the `challenge_endpoint` parameter, the `attest_jwt_client_auth_dpop` authentication method, and the `OAuth-Client-Attestation-Challenge` header (draft 09).
+- `verifyClientAttestationPopJwt` accepts an `expectedAudience` option so a resource server can verify a PoP JWT bound to its own identifier (draft 09).

--- a/.changeset/wallet-attestation-draft-09.md
+++ b/.changeset/wallet-attestation-draft-09.md
@@ -1,5 +1,5 @@
 ---
-"@openid4vc/oauth2": minor
+"@openid4vc/oauth2": patch
 ---
 
 Align wallet (client) attestation with draft 09 of OAuth 2.0 Attestation-Based Client Authentication.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ An implementation of the [OAuth 2.0 Authorization Framework](https://datatracker
 - [RFC 7662 - OAuth 2.0 Token Introspection](https://datatracker.ietf.org/doc/html/rfc7662)
 - [RFC 9068 JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens](https://datatracker.ietf.org/doc/html/rfc9068)
 - [RFC 8707 - Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707.html)
-- [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-07.html)
+- [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-09.html)
 - [RFC 9207 - OAuth 2.0 Authorization Server Issuer Identification](https://www.rfc-editor.org/rfc/rfc9207.html)
 
 ```ts

--- a/packages/oauth2/src/client-attestation/__tests__/client-attestation.test.mts
+++ b/packages/oauth2/src/client-attestation/__tests__/client-attestation.test.mts
@@ -1,0 +1,145 @@
+import * as jose from 'jose'
+import { beforeAll, describe, expect, test } from 'vitest'
+import { callbacks, getSignJwtCallback } from '../../../tests/util.mjs'
+import type { Jwk } from '../../common/jwk/z-jwk'
+import { decodeJwt } from '../../common/jwt/decode-jwt'
+import { createClientAttestationJwt } from '../client-attestation'
+import { createClientAttestationPopJwt, verifyClientAttestationPopJwt } from '../client-attestation-pop'
+import {
+  zClientAttestationJwtHeader,
+  zClientAttestationJwtPayload,
+  zClientAttestationPopJwtHeader,
+  zClientAttestationPopJwtPayload,
+} from '../z-client-attestation'
+
+const authorizationServer = 'https://oauth2-auth-server.com'
+
+async function generateEs256Key() {
+  const { publicKey, privateKey } = await jose.generateKeyPair('ES256', { extractable: true })
+  return {
+    privateJwk: (await jose.exportJWK(privateKey)) as Jwk,
+    publicJwk: (await jose.exportJWK(publicKey)) as Jwk,
+  }
+}
+
+describe('Client (Wallet) Attestation', () => {
+  // Attester signs the client attestation; the client instance holds the `cnf` key and signs the PoP.
+  let attester: Awaited<ReturnType<typeof generateEs256Key>>
+  let instance: Awaited<ReturnType<typeof generateEs256Key>>
+  let signJwt: ReturnType<typeof getSignJwtCallback>
+  let clientAttestationJwt: string
+  let clientAttestation: ReturnType<
+    typeof decodeJwt<typeof zClientAttestationJwtHeader, typeof zClientAttestationJwtPayload>
+  >
+
+  beforeAll(async () => {
+    attester = await generateEs256Key()
+    instance = await generateEs256Key()
+    signJwt = getSignJwtCallback([attester.privateJwk, instance.privateJwk])
+
+    clientAttestationJwt = await createClientAttestationJwt({
+      callbacks: { signJwt },
+      clientId: 'wallet',
+      confirmation: { jwk: instance.publicJwk },
+      expiresAt: new Date(Date.now() + 3600 * 1000),
+      signer: { method: 'jwk', alg: 'ES256', publicJwk: attester.publicJwk },
+    })
+
+    clientAttestation = decodeJwt({
+      jwt: clientAttestationJwt,
+      headerSchema: zClientAttestationJwtHeader,
+      payloadSchema: zClientAttestationJwtPayload,
+    })
+  })
+
+  test('creates a draft-09 Client Attestation JWT without an `iss` claim', () => {
+    expect(clientAttestation.payload.iss).toBeUndefined()
+    expect(clientAttestation.payload.sub).toBe('wallet')
+    expect(clientAttestation.payload.cnf.jwk).toEqual(instance.publicJwk)
+  })
+
+  test('creates a draft-09 PoP JWT (no `iss`, no `exp`, uses `challenge`) that verifies', async () => {
+    const clientAttestationPopJwt = await createClientAttestationPopJwt({
+      callbacks: { signJwt, generateRandom: callbacks.generateRandom },
+      authorizationServer,
+      clientAttestation: clientAttestationJwt,
+      challenge: 'challenge-123',
+    })
+
+    const { payload } = decodeJwt({
+      jwt: clientAttestationPopJwt,
+      headerSchema: zClientAttestationPopJwtHeader,
+      payloadSchema: zClientAttestationPopJwtPayload,
+    })
+    expect(payload.iss).toBeUndefined()
+    expect(payload.exp).toBeUndefined()
+    expect(payload.nonce).toBeUndefined()
+    expect(payload.challenge).toBe('challenge-123')
+    expect(payload.aud).toBe(authorizationServer)
+    expect(payload.jti).toEqual(expect.any(String))
+
+    await expect(
+      verifyClientAttestationPopJwt({
+        callbacks: { verifyJwt: callbacks.verifyJwt },
+        authorizationServer,
+        clientAttestation,
+        clientAttestationPopJwt,
+        expectedChallenge: 'challenge-123',
+      })
+    ).resolves.toBeDefined()
+  })
+
+  test('verifies a legacy (<= draft 07) PoP JWT carrying `iss` and `nonce`', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const { jwt: legacyPopJwt } = await signJwt(
+      { method: 'jwk', alg: 'ES256', publicJwk: instance.publicJwk },
+      {
+        header: { typ: 'oauth-client-attestation-pop+jwt', alg: 'ES256' },
+        payload: {
+          iss: 'wallet',
+          aud: authorizationServer,
+          iat: now,
+          exp: now + 300,
+          jti: 'legacy-jti',
+          nonce: 'legacy-nonce',
+        },
+      }
+    )
+
+    await expect(
+      verifyClientAttestationPopJwt({
+        callbacks: { verifyJwt: callbacks.verifyJwt },
+        authorizationServer,
+        clientAttestation,
+        clientAttestationPopJwt: legacyPopJwt,
+        // `expectedNonce` is the deprecated alias for `expectedChallenge`
+        expectedNonce: 'legacy-nonce',
+      })
+    ).resolves.toBeDefined()
+  })
+
+  test('rejects a legacy PoP JWT whose `iss` does not match the attestation `sub`', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const { jwt: legacyPopJwt } = await signJwt(
+      { method: 'jwk', alg: 'ES256', publicJwk: instance.publicJwk },
+      {
+        header: { typ: 'oauth-client-attestation-pop+jwt', alg: 'ES256' },
+        payload: {
+          iss: 'not-wallet',
+          aud: authorizationServer,
+          iat: now,
+          jti: 'legacy-jti',
+        },
+      }
+    )
+
+    await expect(
+      verifyClientAttestationPopJwt({
+        callbacks: { verifyJwt: callbacks.verifyJwt },
+        authorizationServer,
+        clientAttestation,
+        clientAttestationPopJwt: legacyPopJwt,
+      })
+    ).rejects.toThrow("'iss'")
+  })
+})

--- a/packages/oauth2/src/client-attestation/client-attestation-pop.ts
+++ b/packages/oauth2/src/client-attestation/client-attestation-pop.ts
@@ -1,4 +1,4 @@
-import { addSecondsToDate, dateToSeconds, encodeToBase64Url, parseWithErrorHandling } from '@openid4vc/utils'
+import { dateToSeconds, encodeToBase64Url, parseWithErrorHandling } from '@openid4vc/utils'
 import type { CallbackContext } from '../callbacks'
 import { decodeJwt } from '../common/jwt/decode-jwt'
 import { verifyJwt } from '../common/jwt/verify-jwt'
@@ -19,16 +19,14 @@ import {
 
 export interface RequestClientAttestationOptions {
   /**
-   * Dpop nonce to use for constructing the client attestation pop jwt
+   * The challenge provided by the authorization server to include in the client attestation pop jwt.
    */
-  nonce?: string
+  challenge?: string
 
   /**
-   * Expiration time of the client attestation pop jwt.
-   *
-   * @default 5 minutes after issuance date
+   * @deprecated Renamed to `challenge` in draft 06. If `challenge` is not set, this value is used.
    */
-  expiresAt?: Date
+  nonce?: string
 
   /**
    * The client attestation jwt to create the pop for.
@@ -53,10 +51,9 @@ export async function createClientAttestationForRequest(
     authorizationServer: options.authorizationServer,
     clientAttestation: options.clientAttestation.jwt,
     callbacks: options.callbacks,
-    expiresAt: options.clientAttestation.expiresAt,
     signer: options.clientAttestation.signer,
-    // TODO: support dynamic fetching of the nonce
-    nonce: options.clientAttestation.nonce,
+    // TODO: support dynamic fetching of the challenge from the `challenge_endpoint`
+    challenge: options.clientAttestation.challenge ?? options.clientAttestation.nonce,
   })
 
   return {
@@ -74,12 +71,29 @@ export interface VerifyClientAttestationPopJwtOptions {
   clientAttestationPopJwt: string
 
   /**
-   * The issuer identifier of the authorization server handling the client attestation
+   * The issuer identifier of the authorization server handling the client attestation.
    */
   authorizationServer: string
 
   /**
-   * Expected nonce in the payload. If not provided the nonce won't be validated.
+   * The expected value of the `aud` claim. Defaults to `authorizationServer`.
+   *
+   * draft 09 allows the audience to be a Resource Server identifier URL in addition to the
+   * authorization server issuer URL; set this when verifying a PoP JWT at a resource server.
+   */
+  expectedAudience?: string
+
+  /**
+   * Expected challenge in the payload. If not provided the challenge won't be validated.
+   *
+   * Matched against the `challenge` claim (draft 06+) and, for backwards compatibility,
+   * the legacy `nonce` claim.
+   */
+  expectedChallenge?: string
+
+  /**
+   * @deprecated Renamed to `expectedChallenge` in draft 06. If `expectedChallenge` is not set,
+   * this value is used.
    */
   expectedNonce?: string
 
@@ -118,10 +132,18 @@ export async function verifyClientAttestationPopJwt(options: VerifyClientAttesta
     payloadSchema: zClientAttestationPopJwtPayload,
   })
 
-  if (payload.iss !== options.clientAttestation.payload.sub) {
+  // `iss` was removed from the Client Attestation PoP JWT in draft 08. Only validate it against
+  // the client attestation `sub` when a legacy (<= draft 07) PoP JWT still includes it.
+  if (payload.iss !== undefined && payload.iss !== options.clientAttestation.payload.sub) {
     throw new Oauth2Error(
       `Client Attestation Pop jwt contains 'iss' (client_id) value '${payload.iss}', but expected 'sub' value from client attestation '${options.clientAttestation.payload.sub}'`
     )
+  }
+
+  // `challenge` (draft 06+) replaced `nonce`. Accept either claim for backwards compatibility.
+  const expectedChallenge = options.expectedChallenge ?? options.expectedNonce
+  if (expectedChallenge !== undefined && expectedChallenge !== (payload.challenge ?? payload.nonce)) {
+    throw new Oauth2Error("Client Attestation Pop jwt 'challenge' does not match expected value.")
   }
 
   const { signer } = await verifyJwt({
@@ -132,9 +154,8 @@ export async function verifyClientAttestationPopJwt(options: VerifyClientAttesta
     },
     now: options.now,
     header,
-    expectedNonce: options.expectedNonce,
     payload,
-    expectedAudience: options.authorizationServer,
+    expectedAudience: options.expectedAudience ?? options.authorizationServer,
     compact: options.clientAttestationPopJwt,
     verifyJwtCallback: options.callbacks.verifyJwt,
     errorMessage: 'client attestation pop jwt verification failed',
@@ -150,7 +171,12 @@ export async function verifyClientAttestationPopJwt(options: VerifyClientAttesta
 
 export interface CreateClientAttestationPopJwtOptions {
   /**
-   * Client attestation Pop nonce value
+   * The challenge provided by the authorization server to include in the client attestation pop jwt.
+   */
+  challenge?: string
+
+  /**
+   * @deprecated Renamed to `challenge` in draft 06. If `challenge` is not set, this value is used.
    */
   nonce?: string
 
@@ -163,11 +189,6 @@ export interface CreateClientAttestationPopJwtOptions {
    * Creation time of the JWT. If not provided the current date will be used
    */
   issuedAt?: Date
-
-  /**
-   * Expiration time of the JWT. If not proided 1 minute will be added to the `issuedAt`
-   */
-  expiresAt?: Date
 
   /**
    * The client attestation to create the Pop for
@@ -212,15 +233,13 @@ export async function createClientAttestationPopJwt(options: CreateClientAttesta
     alg: signer.alg,
   } satisfies ClientAttestationPopJwtHeader)
 
-  const expiresAt = options.expiresAt ?? addSecondsToDate(options.issuedAt ?? new Date(), 1 * 60)
-
+  // `iss` (removed in draft 08) and `exp` (removed in draft 06) are no longer part of the
+  // Client Attestation PoP JWT. `challenge` (draft 06+) replaces the legacy `nonce`.
   const payload = parseWithErrorHandling(zClientAttestationPopJwtPayload, {
     aud: options.authorizationServer,
-    iss: clientAttestation.payload.sub,
-    iat: dateToSeconds(options.issuedAt),
-    exp: dateToSeconds(expiresAt),
+    iat: dateToSeconds(options.issuedAt ?? new Date()),
     jti: encodeToBase64Url(await options.callbacks.generateRandom(32)),
-    nonce: options.nonce,
+    challenge: options.challenge ?? options.nonce,
     ...options.additionalPayload,
   } satisfies ClientAttestationPopJwtPayload)
 

--- a/packages/oauth2/src/client-attestation/client-attestation.ts
+++ b/packages/oauth2/src/client-attestation/client-attestation.ts
@@ -80,11 +80,11 @@ export interface CreateClientAttestationJwtOptions {
   expiresAt: Date
 
   /**
-   * Issuer of the client attestation, usually identifier of the client backend.
+   * Issuer of the client attestation, usually the identifier of the client backend (attester).
    *
-   * @deprecated The `iss` claim was removed from the Client Attestation JWT in draft 08. This
-   * option is retained for backwards compatibility with <= draft 07 verifiers; if provided the
-   * `iss` claim will still be included in the payload.
+   * The `iss` claim was removed from the Client Attestation JWT in draft 08, so it is only
+   * included in the payload when this option is provided. It is also useful for interoperability
+   * with <= draft 07 verifiers and when the KID is a relative DID URL to the issuer.
    */
   issuer?: string
 

--- a/packages/oauth2/src/client-attestation/client-attestation.ts
+++ b/packages/oauth2/src/client-attestation/client-attestation.ts
@@ -80,9 +80,13 @@ export interface CreateClientAttestationJwtOptions {
   expiresAt: Date
 
   /**
-   * Issuer of the client attestation, usually identifier of the client backend
+   * Issuer of the client attestation, usually identifier of the client backend.
+   *
+   * @deprecated The `iss` claim was removed from the Client Attestation JWT in draft 08. This
+   * option is retained for backwards compatibility with <= draft 07 verifiers; if provided the
+   * `iss` claim will still be included in the payload.
    */
-  issuer: string
+  issuer?: string
 
   /**
    * The client id of the client instance.
@@ -118,7 +122,9 @@ export async function createClientAttestationJwt(options: CreateClientAttestatio
   } satisfies ClientAttestationJwtHeader)
 
   const payload = parseWithErrorHandling(zClientAttestationJwtPayload, {
-    iss: options.issuer,
+    // `iss` was removed from the Client Attestation JWT in draft 08. Only include it when a
+    // legacy `issuer` is explicitly provided.
+    ...(options.issuer ? { iss: options.issuer } : {}),
     iat: dateToSeconds(options.issuedAt),
     exp: dateToSeconds(options.expiresAt),
     sub: options.clientId,

--- a/packages/oauth2/src/client-attestation/z-client-attestation.ts
+++ b/packages/oauth2/src/client-attestation/z-client-attestation.ts
@@ -9,7 +9,6 @@ export const oauthClientAttestationHeader = zOauthClientAttestationHeader.value
 export const zClientAttestationJwtPayload = z
   .object({
     ...zJwtPayload.shape,
-    iss: z.string(),
     sub: z.string(),
     exp: zNumericDate,
     cnf: z
@@ -37,13 +36,20 @@ export type ClientAttestationJwtHeader = z.infer<typeof zClientAttestationJwtHea
 export const zOauthClientAttestationPopHeader = z.literal('OAuth-Client-Attestation-PoP')
 export const oauthClientAttestationPopHeader = zOauthClientAttestationPopHeader.value
 
+// draft 09: header used by the authorization/resource server to provide a fresh challenge.
+export const zOauthClientAttestationChallengeHeader = z.literal('OAuth-Client-Attestation-Challenge')
+export const oauthClientAttestationChallengeHeader = zOauthClientAttestationChallengeHeader.value
+
 export const zClientAttestationPopJwtPayload = z
   .object({
     ...zJwtPayload.shape,
-    iss: z.string(),
     aud: z.union([zHttpsUrl, z.array(zHttpsUrl)]),
 
     jti: z.string(),
+
+    // `challenge` (draft 06+) replaced `nonce`. Both are accepted on verification; `nonce`
+    // is retained only for backwards compatibility with <= draft 05 PoP JWTs.
+    challenge: z.optional(z.string()),
     nonce: z.optional(z.string()),
   })
   .loose()

--- a/packages/oauth2/src/client-authentication.ts
+++ b/packages/oauth2/src/client-authentication.ts
@@ -14,6 +14,8 @@ export enum SupportedClientAuthenticationMethod {
   ClientSecretBasic = 'client_secret_basic',
   ClientSecretPost = 'client_secret_post',
   ClientAttestationJwt = 'attest_jwt_client_auth',
+  // DPoP-bound variant introduced in draft 09.
+  ClientAttestationJwtDpop = 'attest_jwt_client_auth_dpop',
   None = 'none',
 }
 
@@ -222,6 +224,12 @@ export function clientAuthenticationAnonymous(): ClientAuthenticationCallback {
 export interface ClientAuthenticationClientAttestationJwtOptions {
   clientAttestationJwt: string
   callbacks: Pick<CallbackContext, 'signJwt' | 'generateRandom'>
+
+  /**
+   * Challenge provided by the authorization server (e.g. obtained from its `challenge_endpoint`)
+   * to include in the Client Attestation PoP JWT.
+   */
+  challenge?: string
 }
 
 /**
@@ -236,11 +244,9 @@ export function clientAuthenticationClientAttestationJwt(
       callbacks: options.callbacks,
       clientAttestation: options.clientAttestationJwt,
 
-      // TODO: support client attestation nonce
-      // We can fetch it before making the request if we don't have a nonce
-      // https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-05.html
-      // https://github.com/oauth-wg/draft-ietf-oauth-attestation-based-client-auth/issues/101
-      // nonce:
+      // TODO: support dynamically fetching the challenge from the `challenge_endpoint`
+      // https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-09.html
+      challenge: options.challenge,
     })
 
     headers.set(oauthClientAttestationHeader, options.clientAttestationJwt)

--- a/packages/oauth2/src/metadata/authorization-server/z-authorization-server-metadata.ts
+++ b/packages/oauth2/src/metadata/authorization-server/z-authorization-server-metadata.ts
@@ -6,6 +6,7 @@ const knownClientAuthenticationMethod = z.enum([
   'client_secret_basic',
   'client_secret_post',
   'attest_jwt_client_auth',
+  'attest_jwt_client_auth_dpop',
   'client_secret_jwt',
   'private_key_jwt',
 ])
@@ -46,7 +47,13 @@ export const zAuthorizationServerMetadata = z
     // From OpenID4VCI specification
     'pre-authorized_grant_anonymous_access_supported': z.optional(z.boolean()),
 
-    // Attestation Based Client Auth (draft 5)
+    // OAuth 2.0 Attestation-Based Client Authentication (draft 09)
+    client_attestation_signing_alg_values_supported: z.optional(z.array(zAlgValueNotNone)),
+    client_attestation_pop_signing_alg_values_supported: z.optional(z.array(zAlgValueNotNone)),
+    // Endpoint from which the client can obtain a fresh challenge for the Client Attestation PoP JWT.
+    challenge_endpoint: z.optional(zHttpsUrl),
+
+    // Non-standard (draft 05 era); retained for backwards compatibility. Not part of draft 06+.
     client_attestation_pop_nonce_required: z.boolean().optional(),
 
     // RFC9207

--- a/packages/openid4vci/tests/full-flow.test.mts
+++ b/packages/openid4vci/tests/full-flow.test.mts
@@ -581,10 +581,8 @@ describe('Full E2E test', () => {
               typ: 'oauth-client-attestation-pop+jwt',
             },
             payload: {
-              iss: 'wallet',
               aud: 'https://oauth2-auth-server.com',
               iat: expect.any(Number),
-              exp: expect.any(Number),
               jti: expect.any(String),
             },
             signer: {


### PR DESCRIPTION
Updates the current implementation to support Draft 9 of wallet attestations in a backwards compatible way.

Maybe it's worth considering not doing it backwards compatible since it's a draft, and we can simplify a bit.