### PR TITLE
feat: allow auth and jwks metadata fetch via callback

### DIFF
--- a/.changeset/metadata-and-jwks-callbacks.md
+++ b/.changeset/metadata-and-jwks-callbacks.md
@@ -1,0 +1,15 @@
+---
+'@openid4vc/oauth2': patch
+'@openid4vc/openid4vci': patch
+'@openid4vc/openid4vp': patch
+---
+
+Add `getAuthorizationServerMetadata` and `getJwks` callbacks to the `CallbackContext`, allowing authorization server metadata and JWK Sets to be resolved without performing a request.
+
+This makes it possible to avoid network requests for metadata and keys that the caller already has (for example an authorization server hosted by the same application, which would otherwise result in an HTTP request to itself when verifying an access token it issued), and to serve metadata and keys from a cache.
+
+Both callbacks are optional. If not provided, or if they return `undefined`, the metadata and JWK Sets are fetched over HTTP as before. `getAuthorizationServerMetadata` can additionally return `null` to indicate the metadata definitively does not exist, so it is not requested again.
+
+Values returned by the callbacks are validated exactly like fetched values: a JWK Set is parsed with the JWK Set schema, and authorization server metadata is parsed with the authorization server metadata schema and must have an `issuer` matching the requested issuer.
+
+The second parameter of the exported `fetchJwks` and `fetchAuthorizationServerMetadata` functions now also accepts an object with `fetch` and the matching resolve callback, in addition to the `Fetch` implementation it accepted before.

--- a/packages/oauth2/src/Oauth2Client.ts
+++ b/packages/oauth2/src/Oauth2Client.ts
@@ -81,7 +81,7 @@ export class Oauth2Client {
   }
 
   public async fetchAuthorizationServerMetadata(issuer: string) {
-    return fetchAuthorizationServerMetadata(issuer, this.options.callbacks.fetch)
+    return fetchAuthorizationServerMetadata(issuer, this.options.callbacks)
   }
 
   /**

--- a/packages/oauth2/src/Oauth2ResourceServer.ts
+++ b/packages/oauth2/src/Oauth2ResourceServer.ts
@@ -5,7 +5,7 @@ export interface Oauth2ResourceServerOptions {
   /**
    * Callbacks required for the oauth2 resource server
    */
-  callbacks: Pick<CallbackContext, 'verifyJwt' | 'hash' | 'clientAuthentication' | 'fetch'>
+  callbacks: Pick<CallbackContext, 'verifyJwt' | 'hash' | 'clientAuthentication' | 'fetch' | 'getJwks'>
 }
 
 export class Oauth2ResourceServer {

--- a/packages/oauth2/src/__tests__/Oauth2ResourceServer.test.mts
+++ b/packages/oauth2/src/__tests__/Oauth2ResourceServer.test.mts
@@ -132,4 +132,165 @@ describe('Oauth2ResourceServer', () => {
       sub: 'pre-auth-code',
     })
   })
+
+  test('verifies resource request using the getJwks callback, without fetching the jwks_uri', async () => {
+    let jwksRequestCount = 0
+    server.resetHandlers(
+      http.get(authorizationServerMetadata.jwks_uri, () => {
+        jwksRequestCount++
+        return HttpResponse.json({ keys: [accessTokenSignerJwkPublic] } satisfies JwkSet, {
+          headers: { 'Content-Type': ContentType.JwkSet },
+        })
+      })
+    )
+
+    const requestedJwksUris: string[] = []
+    const resourceServer = new Oauth2ResourceServer({
+      callbacks: {
+        ...callbacks,
+        fetch,
+        getJwks: (jwksUri) => {
+          requestedJwksUris.push(jwksUri)
+          return { keys: [accessTokenSignerJwkPublic] }
+        },
+      },
+    })
+
+    const { jwt } = await createAccessTokenJwt({
+      audience: 'https://resource-server.com',
+      authorizationServer: authorizationServerMetadata.issuer,
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([accessTokenSignerJwk]),
+      },
+      expiresInSeconds: 300,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: accessTokenSignerJwkPublic,
+      },
+      subject: 'pre-auth-code',
+      now: new Date('2024-10-01'),
+    })
+
+    const { tokenPayload } = await resourceServer.verifyResourceRequest({
+      authorizationServers: [authorizationServerMetadata],
+      request: {
+        method: 'POST',
+        url: 'https://resource-server.com/endpoint',
+        headers: new Headers({ Authorization: `Bearer ${jwt}` }),
+      },
+      now: new Date('2024-10-01'),
+      resourceServer: 'https://resource-server.com',
+    })
+
+    expect(tokenPayload.sub).toEqual('pre-auth-code')
+    expect(requestedJwksUris).toEqual([authorizationServerMetadata.jwks_uri])
+    expect(jwksRequestCount).toEqual(0)
+  })
+
+  test('rejects a jwks from the getJwks callback that does not pass validation', async () => {
+    let jwksRequestCount = 0
+    server.resetHandlers(
+      http.get(authorizationServerMetadata.jwks_uri, () => {
+        jwksRequestCount++
+        return HttpResponse.json({ keys: [accessTokenSignerJwkPublic] } satisfies JwkSet, {
+          headers: { 'Content-Type': ContentType.JwkSet },
+        })
+      })
+    )
+
+    const resourceServer = new Oauth2ResourceServer({
+      callbacks: {
+        ...callbacks,
+        fetch,
+        // Not a valid jwk set, `keys` must be an array of jwks
+        getJwks: () => ({ keys: 'not-an-array' }) as unknown as JwkSet,
+      },
+    })
+
+    const { jwt } = await createAccessTokenJwt({
+      audience: 'https://resource-server.com',
+      authorizationServer: authorizationServerMetadata.issuer,
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([accessTokenSignerJwk]),
+      },
+      expiresInSeconds: 300,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: accessTokenSignerJwkPublic,
+      },
+      subject: 'pre-auth-code',
+      now: new Date('2024-10-01'),
+    })
+
+    await expect(
+      resourceServer.verifyResourceRequest({
+        authorizationServers: [authorizationServerMetadata],
+        request: {
+          method: 'POST',
+          url: 'https://resource-server.com/endpoint',
+          headers: new Headers({ Authorization: `Bearer ${jwt}` }),
+        },
+        now: new Date('2024-10-01'),
+        resourceServer: 'https://resource-server.com',
+      })
+    ).rejects.toThrow()
+
+    // The invalid jwks is rejected, it does not silently fall back to fetching
+    expect(jwksRequestCount).toEqual(0)
+  })
+
+  test('falls back to fetching the jwks_uri if the getJwks callback returns undefined', async () => {
+    let jwksRequestCount = 0
+    server.resetHandlers(
+      http.get(authorizationServerMetadata.jwks_uri, () => {
+        jwksRequestCount++
+        return HttpResponse.json({ keys: [accessTokenSignerJwkPublic] } satisfies JwkSet, {
+          headers: { 'Content-Type': ContentType.JwkSet },
+        })
+      })
+    )
+
+    const resourceServer = new Oauth2ResourceServer({
+      callbacks: {
+        ...callbacks,
+        fetch,
+        getJwks: () => undefined,
+      },
+    })
+
+    const { jwt } = await createAccessTokenJwt({
+      audience: 'https://resource-server.com',
+      authorizationServer: authorizationServerMetadata.issuer,
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([accessTokenSignerJwk]),
+      },
+      expiresInSeconds: 300,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: accessTokenSignerJwkPublic,
+      },
+      subject: 'pre-auth-code',
+      now: new Date('2024-10-01'),
+    })
+
+    const { tokenPayload } = await resourceServer.verifyResourceRequest({
+      authorizationServers: [authorizationServerMetadata],
+      request: {
+        method: 'POST',
+        url: 'https://resource-server.com/endpoint',
+        headers: new Headers({ Authorization: `Bearer ${jwt}` }),
+      },
+      now: new Date('2024-10-01'),
+      resourceServer: 'https://resource-server.com',
+    })
+
+    expect(tokenPayload.sub).toEqual('pre-auth-code')
+    expect(jwksRequestCount).toEqual(1)
+  })
 })

--- a/packages/oauth2/src/__tests__/fetch-authorization-server-metadata.test.mts
+++ b/packages/oauth2/src/__tests__/fetch-authorization-server-metadata.test.mts
@@ -1,0 +1,103 @@
+import { ValidationError } from '@openid4vc/utils'
+import { HttpResponse, http } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+import { Oauth2Error } from '../error/Oauth2Error'
+import { fetchAuthorizationServerMetadata } from '../metadata/authorization-server/authorization-server-metadata'
+import type { AuthorizationServerMetadata } from '../metadata/authorization-server/z-authorization-server-metadata'
+
+const server = setupServer()
+
+const issuer = 'https://authorization-server.com'
+const authorizationServerMetadata = {
+  issuer,
+  token_endpoint: 'https://authorization-server.com/token',
+  jwks_uri: 'https://authorization-server.com/jwks.json',
+} satisfies AuthorizationServerMetadata
+
+describe('fetchAuthorizationServerMetadata', () => {
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  test('uses metadata from the getAuthorizationServerMetadata callback without performing a request', async () => {
+    let wellKnownRequestCount = 0
+    server.resetHandlers(
+      http.get('https://authorization-server.com/.well-known/*', () => {
+        wellKnownRequestCount++
+        return HttpResponse.json(authorizationServerMetadata)
+      })
+    )
+
+    const requestedIssuers: string[] = []
+    const metadata = await fetchAuthorizationServerMetadata(issuer, {
+      fetch,
+      getAuthorizationServerMetadata: (requestedIssuer) => {
+        requestedIssuers.push(requestedIssuer)
+        return authorizationServerMetadata
+      },
+    })
+
+    expect(metadata).toEqual(authorizationServerMetadata)
+    expect(requestedIssuers).toEqual([issuer])
+    expect(wellKnownRequestCount).toEqual(0)
+  })
+
+  test('returns null without performing a request if the callback returns null', async () => {
+    let wellKnownRequestCount = 0
+    server.resetHandlers(
+      http.get('https://authorization-server.com/.well-known/*', () => {
+        wellKnownRequestCount++
+        return HttpResponse.json(authorizationServerMetadata)
+      })
+    )
+
+    const metadata = await fetchAuthorizationServerMetadata(issuer, {
+      fetch,
+      getAuthorizationServerMetadata: () => null,
+    })
+
+    expect(metadata).toBeNull()
+    expect(wellKnownRequestCount).toEqual(0)
+  })
+
+  test('falls back to fetching if the callback returns undefined', async () => {
+    let wellKnownRequestCount = 0
+    server.resetHandlers(
+      http.get('https://authorization-server.com/.well-known/oauth-authorization-server', () => {
+        wellKnownRequestCount++
+        return HttpResponse.json(authorizationServerMetadata)
+      })
+    )
+
+    const metadata = await fetchAuthorizationServerMetadata(issuer, {
+      fetch,
+      getAuthorizationServerMetadata: () => undefined,
+    })
+
+    expect(metadata).toEqual(authorizationServerMetadata)
+    expect(wellKnownRequestCount).toEqual(1)
+  })
+
+  test('throws if the callback returns metadata that does not pass validation', async () => {
+    await expect(
+      fetchAuthorizationServerMetadata(issuer, {
+        fetch,
+        // Missing the required `token_endpoint`
+        getAuthorizationServerMetadata: () => ({ issuer }) as AuthorizationServerMetadata,
+      })
+    ).rejects.toThrow(ValidationError)
+  })
+
+  test('throws if the callback returns metadata for a different issuer', async () => {
+    await expect(
+      fetchAuthorizationServerMetadata(issuer, {
+        fetch,
+        getAuthorizationServerMetadata: () => ({
+          ...authorizationServerMetadata,
+          issuer: 'https://another-authorization-server.com',
+        }),
+      })
+    ).rejects.toThrow(Oauth2Error)
+  })
+})

--- a/packages/oauth2/src/access-token/verify-access-token.ts
+++ b/packages/oauth2/src/access-token/verify-access-token.ts
@@ -21,7 +21,7 @@ export interface VerifyJwtProfileAccessTokenOptions {
   /**
    * Callbacks used for verifying the access token
    */
-  callbacks: Pick<CallbackContext, 'verifyJwt' | 'fetch'>
+  callbacks: Pick<CallbackContext, 'verifyJwt' | 'fetch' | 'getJwks'>
 
   /**
    * If not provided current time will be used
@@ -69,7 +69,7 @@ export async function verifyJwtProfileAccessToken(options: VerifyJwtProfileAcces
     )
   }
 
-  const jwks = await fetchJwks(jwksUrl, options.callbacks.fetch)
+  const jwks = await fetchJwks(jwksUrl, options.callbacks)
   const publicJwk = extractJwkFromJwksForJwt({
     kid: decodedJwt.header.kid,
     jwks,

--- a/packages/oauth2/src/callbacks.ts
+++ b/packages/oauth2/src/callbacks.ts
@@ -1,7 +1,8 @@
 import type { Fetch, OrPromise } from '@openid4vc/utils'
 import type { ClientAuthenticationCallback } from './client-authentication'
-import type { Jwk } from './common/jwk/z-jwk'
+import type { Jwk, JwkSet } from './common/jwk/z-jwk'
 import type { JweEncryptor, JwtHeader, JwtPayload, JwtSigner } from './common/jwt/z-jwt'
+import type { AuthorizationServerMetadata } from './metadata/authorization-server/z-authorization-server-metadata'
 
 /**
  * Supported hashing algorithms
@@ -77,6 +78,43 @@ export type DecryptJweCallback = (
     }
 >
 
+/**
+ * Callback to resolve authorization server metadata without fetching it from the well-known
+ * endpoints of the authorization server.
+ *
+ * The return value determines what happens next:
+ * - metadata: used as-is, no request is performed.
+ * - `undefined`: falls back to fetching the metadata over HTTP.
+ * - `null`: the metadata definitively does not exist. No request is performed and the caller is
+ *   told the metadata was not found. Return this instead of `undefined` when the callback already
+ *   performed its own lookup, so the metadata is not requested a second time.
+ *
+ * The returned metadata is validated against the authorization server metadata schema and its
+ * `issuer` MUST match the requested issuer, exactly as for fetched metadata. What the library
+ * cannot check is where the metadata came from: it is used in place of the metadata that would
+ * have been retrieved from the authorization server, so it MUST be at least as trustworthy. Only
+ * return metadata you control (e.g. an authorization server hosted by this same application) or
+ * metadata from a cache that you populated from a previous fetch for the same issuer.
+ */
+export type GetAuthorizationServerMetadataCallback = (
+  issuer: string
+) => OrPromise<AuthorizationServerMetadata | undefined | null>
+
+/**
+ * Callback to resolve a JWK Set without fetching it from the `jwks_uri`.
+ *
+ * Return `undefined` to fall back to fetching the JWK Set over HTTP.
+ *
+ * The returned JWK Set is validated against the JWK Set schema, exactly as for a fetched JWK Set.
+ * What the library cannot check is where the keys came from: they are used to verify signatures in
+ * place of the JWK Set that would have been fetched from `jwksUri`, so they MUST be at least as
+ * trustworthy. Only return keys you control (e.g. the signing keys of an authorization server
+ * hosted by this same application) or keys from a cache that you populated from a previous fetch
+ * of the same `jwksUri`. Returning keys for a `jwksUri` you do not control allows arbitrary
+ * signatures to be accepted.
+ */
+export type GetJwksCallback = (jwksUri: string) => OrPromise<JwkSet | undefined>
+
 export type EncryptJweCallback = (
   jweEncryptor: JweEncryptor,
   data: string
@@ -93,6 +131,24 @@ export interface CallbackContext {
    * Custom fetch implementation to use
    */
   fetch?: Fetch
+
+  /**
+   * Optional callback to resolve authorization server metadata without performing a well-known
+   * request. Useful to avoid network requests for authorization servers hosted by this same
+   * application, or to serve metadata from a cache.
+   *
+   * If not provided, or if it returns `undefined`, the metadata is fetched over HTTP.
+   */
+  getAuthorizationServerMetadata?: GetAuthorizationServerMetadataCallback
+
+  /**
+   * Optional callback to resolve a JWK Set without performing a request to the `jwks_uri`. Useful
+   * to avoid network requests for keys held by this same application, or to serve a JWK Set from a
+   * cache.
+   *
+   * If not provided, or if it returns `undefined`, the JWK Set is fetched over HTTP.
+   */
+  getJwks?: GetJwksCallback
 
   /**
    * Hash callback used for e.g. dpop and pkce

--- a/packages/oauth2/src/id-token/verify-id-token.ts
+++ b/packages/oauth2/src/id-token/verify-id-token.ts
@@ -16,7 +16,7 @@ export interface VerifyIdTokenJwtOptions {
   /**
    * Callbacks used for verifying the id token
    */
-  callbacks: Pick<CallbackContext, 'verifyJwt' | 'fetch'>
+  callbacks: Pick<CallbackContext, 'verifyJwt' | 'fetch' | 'getJwks'>
 
   /**
    * If not provided current time will be used
@@ -66,7 +66,7 @@ export async function verifyIdTokenJwt(options: VerifyIdTokenJwtOptions) {
     throw new Oauth2Error(`Invalid 'azp' claim in id token jwt. Expected '${options.clientId}', got '${payload.azp}'.`)
   }
 
-  const jwks = await fetchJwks(jwksUrl, options.callbacks.fetch)
+  const jwks = await fetchJwks(jwksUrl, options.callbacks)
   const publicJwk = extractJwkFromJwksForJwt({
     kid: header.kid,
     jwks,

--- a/packages/oauth2/src/index.ts
+++ b/packages/oauth2/src/index.ts
@@ -70,6 +70,8 @@ export type {
   DecryptJweCallbackOptions,
   EncryptJweCallback,
   GenerateRandomCallback,
+  GetAuthorizationServerMetadataCallback,
+  GetJwksCallback,
   HashCallback,
   SignJwtCallback,
   VerifyDataIntegrityProofCallback,

--- a/packages/oauth2/src/metadata/authorization-server/authorization-server-metadata.ts
+++ b/packages/oauth2/src/metadata/authorization-server/authorization-server-metadata.ts
@@ -1,4 +1,5 @@
-import { type Fetch, joinUriParts, OpenId4VcBaseError, URL } from '@openid4vc/utils'
+import { type Fetch, joinUriParts, OpenId4VcBaseError, parseWithErrorHandling, URL } from '@openid4vc/utils'
+import type { CallbackContext } from '../../callbacks'
 import { Oauth2Error } from '../../error/Oauth2Error'
 import { fetchWellKnownMetadata } from '../fetch-well-known-metadata'
 import { type AuthorizationServerMetadata, zAuthorizationServerMetadata } from './z-authorization-server-metadata'
@@ -9,11 +10,40 @@ const wellKnownOpenIdConfigurationServerSuffix = '.well-known/openid-configurati
 /**
  * fetch authorization server metadata. It first tries to fetch the oauth-authorization-server metadata. If that returns
  *  a 404, the openid-configuration metadata will be fetched.
+ *
+ * If a `getAuthorizationServerMetadata` callback is provided and returns metadata for the `issuer`,
+ * that metadata is returned and no requests are performed. The `issuer` value of the returned
+ * metadata MUST still match the requested `issuer`.
  */
 export async function fetchAuthorizationServerMetadata(
   issuer: string,
-  fetch?: Fetch
+  callbacksOrFetch?: Fetch | Pick<CallbackContext, 'fetch' | 'getAuthorizationServerMetadata'>
 ): Promise<AuthorizationServerMetadata | null> {
+  const callbacks = typeof callbacksOrFetch === 'function' ? { fetch: callbacksOrFetch } : callbacksOrFetch
+  const providedMetadata = await callbacks?.getAuthorizationServerMetadata?.(issuer)
+
+  // `null` means the callback determined the metadata does not exist, so we don't fetch it again.
+  if (providedMetadata === null) return null
+
+  if (providedMetadata) {
+    // Validated the same way as metadata retrieved from the well known endpoints
+    const parsedMetadata = parseWithErrorHandling(
+      zAuthorizationServerMetadata,
+      providedMetadata,
+      `Validation of authorization server metadata provided by the 'getAuthorizationServerMetadata' callback for issuer '${issuer}' failed`
+    )
+
+    if (parsedMetadata.issuer !== issuer) {
+      // issuer param MUST match, also for metadata that was not fetched
+      throw new Oauth2Error(
+        `The 'issuer' parameter '${parsedMetadata.issuer}' in the authorization server metadata provided by the 'getAuthorizationServerMetadata' callback does not match the provided issuer '${issuer}'.`
+      )
+    }
+
+    return parsedMetadata
+  }
+
+  const fetch = callbacks?.fetch
   const parsedIssuerUrl = new URL(issuer)
 
   const openIdConfigurationWellKnownMetadataUrl = joinUriParts(issuer, [wellKnownOpenIdConfigurationServerSuffix])

--- a/packages/oauth2/src/metadata/fetch-jwks-uri.ts
+++ b/packages/oauth2/src/metadata/fetch-jwks-uri.ts
@@ -1,18 +1,42 @@
-import { ContentType, createZodFetcher, type Fetch, InvalidFetchResponseError } from '@openid4vc/utils'
+import {
+  ContentType,
+  createZodFetcher,
+  type Fetch,
+  InvalidFetchResponseError,
+  parseWithErrorHandling,
+} from '@openid4vc/utils'
 import { ValidationError } from '../../../utils/src/error/ValidationError'
+import type { CallbackContext } from '../callbacks'
 import { type JwkSet, zJwkSet } from '../common/jwk/z-jwk'
 
 /**
  * Fetch JWKs from a provided JWKs URI.
  *
+ * If a `getJwks` callback is provided and returns a JWK Set for the `jwksUrl`, that JWK Set is
+ * returned and no request is performed.
+ *
  * Returns validated metadata if successful response
  * Throws error otherwise
  *
  * @throws {ValidationError} if successful response but validation of response failed
- * @throws {InvalidFetchResponseError} if unsuccesful response
+ * @throws {InvalidFetchResponseError} if unsuccessful response
  */
-export async function fetchJwks(jwksUrl: string, fetch?: Fetch): Promise<JwkSet> {
-  const fetcher = createZodFetcher(fetch)
+export async function fetchJwks(
+  jwksUrl: string,
+  fetchOrCallbacks?: Fetch | Pick<CallbackContext, 'fetch' | 'getJwks'>
+): Promise<JwkSet> {
+  const callbacks = typeof fetchOrCallbacks === 'function' ? { fetch: fetchOrCallbacks } : fetchOrCallbacks
+  const providedJwks = await callbacks?.getJwks?.(jwksUrl)
+  if (providedJwks) {
+    // Validated the same way as JWKs retrieved from the jwks_uri
+    return parseWithErrorHandling(
+      zJwkSet,
+      providedJwks,
+      `Validation of JWKs provided by the 'getJwks' callback for jwks_uri '${jwksUrl}' failed`
+    )
+  }
+
+  const fetcher = createZodFetcher(callbacks?.fetch)
 
   const { result, response } = await fetcher(zJwkSet, [ContentType.JwkSet, ContentType.Json], jwksUrl)
   if (!response.ok) {

--- a/packages/oauth2/src/resource-request/verify-resource-request.ts
+++ b/packages/oauth2/src/resource-request/verify-resource-request.ts
@@ -27,10 +27,10 @@ export interface VerifyResourceRequestOptions {
   /**
    * Callbacks for verification of the access token.
    */
-  callbacks: Pick<CallbackContext, 'verifyJwt' | 'hash' | 'clientAuthentication' | 'fetch'>
+  callbacks: Pick<CallbackContext, 'verifyJwt' | 'hash' | 'clientAuthentication' | 'fetch' | 'getJwks'>
 
   /**
-   * allowed auth schems for the access token. If not provided
+   * allowed auth schemes for the access token. If not provided
    * all supported authentication schemes are allowed.
    */
   allowedAuthenticationSchemes?: SupportedAuthenticationScheme[]
@@ -48,7 +48,7 @@ export async function verifyResourceRequest(options: VerifyResourceRequestOption
     options.allowedAuthenticationSchemes ?? Object.values(SupportedAuthenticationScheme)
   if (allowedAuthenticationSchemes.length === 0) {
     throw new Oauth2Error(
-      `Emtpy array provided for 'allowedAuthenticationSchemes', provide at least one allowed authentication scheme, or remove the value to allow all supported authentication schemes`
+      `Empty array provided for 'allowedAuthenticationSchemes', provide at least one allowed authentication scheme, or remove the value to allow all supported authentication schemes`
     )
   }
 

--- a/packages/openid4vci/src/metadata/fetch-issuer-metadata.ts
+++ b/packages/openid4vci/src/metadata/fetch-issuer-metadata.ts
@@ -37,12 +37,12 @@ export interface ResolveIssuerMetadataOptions {
   allowAuthorizationMetadataFromCredentialIssuerMetadata?: boolean
 
   /**
-   * Callbacks for fetching the credential issur metadata.
+   * Callbacks for fetching the credential issuer metadata.
    * If no `verifyJwt` callback is provided, the request
    * will not include the `application/jwt` Accept header
    * for signed metadata.
    */
-  callbacks: Partial<Pick<CallbackContext, 'fetch' | 'verifyJwt'>>
+  callbacks: Partial<Pick<CallbackContext, 'fetch' | 'verifyJwt' | 'getAuthorizationServerMetadata'>>
 
   /**
    * Only used for verifying signed issuer metadata. If not provided
@@ -101,10 +101,7 @@ export async function resolveIssuerMetadata(
       continue
     }
 
-    let authorizationServerMetadata = await fetchAuthorizationServerMetadata(
-      authorizationServer,
-      options?.callbacks.fetch
-    )
+    let authorizationServerMetadata = await fetchAuthorizationServerMetadata(authorizationServer, options?.callbacks)
     if (
       !authorizationServerMetadata &&
       authorizationServer === credentialIssuer &&

--- a/packages/openid4vp/src/authorization-response/create-authorization-response.ts
+++ b/packages/openid4vp/src/authorization-response/create-authorization-response.ts
@@ -53,7 +53,7 @@ export interface CreateOpenid4vpAuthorizationResponseOptions {
     audience?: string // The client_id of the client the response is intended for
     expiresInSeconds?: number // The expiration time of the JWT. A maximum JWT lifetime of 10 minutes is RECOMMENDED.
   }
-  callbacks: Pick<CallbackContext, 'signJwt' | 'encryptJwe' | 'fetch'>
+  callbacks: Pick<CallbackContext, 'signJwt' | 'encryptJwe' | 'fetch' | 'getJwks'>
 }
 
 export interface CreateOpenid4vpAuthorizationResponseResult {
@@ -117,7 +117,7 @@ export async function createOpenid4vpAuthorizationResponse(
   if (clientMetadata.jwks) {
     jwks = clientMetadata.jwks
   } else if (clientMetadata.jwks_uri) {
-    jwks = await fetchJwks(clientMetadata.jwks_uri, options.callbacks.fetch)
+    jwks = await fetchJwks(clientMetadata.jwks_uri, options.callbacks)
   } else {
     throw new Oauth2ServerErrorResponseError({
       error: Oauth2ErrorCodes.InvalidRequest,


### PR DESCRIPTION
allows optimization with either caching, or if the to-be-fetched document is already known (e.g. owned by current process)