### PR TITLE
feat(oauth2): freshness validation and replay protection

### DIFF
--- a/.changeset/dpop-freshness-replay.md
+++ b/.changeset/dpop-freshness-replay.md
@@ -1,0 +1,10 @@
+---
+"@openid4vc/oauth2": minor
+---
+
+Add configurable DPoP proof freshness and replay validation hooks.
+
+- Add optional `maxProofAgeSeconds` and `allowedClockSkewSeconds` checks in DPoP verification.
+- Add optional `assertJtiUniqueness` callback for replay protection.
+- Thread these DPoP verification options through access-token, authorization-request, and resource-request verification APIs.
+- Add tests for DPoP validation edge cases and `use_dpop_nonce` retry behavior with fresh proofs.

--- a/packages/oauth2/src/access-token/__tests__/retrieve-access-token.test.mts
+++ b/packages/oauth2/src/access-token/__tests__/retrieve-access-token.test.mts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'vitest'
+import { callbacks, getSignJwtCallback } from '../../../tests/util.mjs'
+import type { Jwk } from '../../common/jwk/z-jwk'
+import { decodeJwt } from '../../common/jwt/decode-jwt'
+import { retrieveAuthorizationCodeAccessToken } from '../retrieve-access-token'
+
+const dpopSignerJwk = {
+  kty: 'EC',
+  d: '6xn3gj1pQisseLDhd1qtGbBr9oWBwxxvAMBSDerbSzk',
+  crv: 'P-256',
+  x: 'CQHN_Jmxy4yDZzDmudBArRip9DtU8bpNDdtya7yj6f4',
+  y: 'sDsPt93iLO7eZdt0-qVwD3bRAaG1V_3wmYdw3dr_lfs',
+} satisfies Jwk
+
+const { d: _, ...dpopSignerJwkPublic } = dpopSignerJwk
+
+describe('retrieveAuthorizationCodeAccessToken', () => {
+  test('retries use_dpop_nonce with a fresh proof', async () => {
+    const dpopProofs: string[] = []
+    let callCount = 0
+
+    const fetchMock: typeof fetch = async (input, init) => {
+      const request = new Request(input, init)
+      const dpop = request.headers.get('DPoP')
+      if (dpop) dpopProofs.push(dpop)
+      callCount++
+
+      if (callCount === 1) {
+        return new Response(JSON.stringify({ error: 'use_dpop_nonce' }), {
+          status: 400,
+          headers: {
+            'Content-Type': 'application/json',
+            'DPoP-Nonce': 'server-nonce',
+          },
+        })
+      }
+
+      return new Response(
+        JSON.stringify({
+          access_token: 'access-token-value',
+          token_type: 'DPoP',
+          expires_in: 300,
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+    }
+
+    const result = await retrieveAuthorizationCodeAccessToken({
+      authorizationServerMetadata: {
+        issuer: 'https://authorization-server.com',
+        token_endpoint: 'https://authorization-server.com/token',
+      },
+      authorizationCode: 'auth-code',
+      callbacks: {
+        ...callbacks,
+        fetch: fetchMock,
+        signJwt: getSignJwtCallback([dpopSignerJwk]),
+      },
+      dpop: {
+        signer: {
+          method: 'jwk',
+          alg: 'ES256',
+          publicJwk: dpopSignerJwkPublic,
+        },
+      },
+    })
+
+    expect(result.accessTokenResponse).toEqual({
+      access_token: 'access-token-value',
+      token_type: 'DPoP',
+      expires_in: 300,
+    })
+
+    expect(callCount).toBe(2)
+    expect(dpopProofs).toHaveLength(2)
+
+    const firstProof = decodeJwt({ jwt: dpopProofs[0] }).payload
+    const secondProof = decodeJwt({ jwt: dpopProofs[1] }).payload
+
+    expect(firstProof.jti).not.toEqual(secondProof.jti)
+    expect(firstProof.nonce).toBeUndefined()
+    expect(secondProof.nonce).toBe('server-nonce')
+  })
+})

--- a/packages/oauth2/src/access-token/verify-access-token-request.ts
+++ b/packages/oauth2/src/access-token/verify-access-token-request.ts
@@ -14,7 +14,7 @@ import { calculateJwkThumbprint } from '../common/jwk/jwk-thumbprint'
 import type { Jwk } from '../common/jwk/z-jwk'
 import type { RequestLike } from '../common/z-common'
 import { Oauth2ErrorCodes } from '../common/z-oauth2-error'
-import { type DpopAssertJtiUniquenessCallback, verifyDpopJwt } from '../dpop/dpop'
+import { type DpopVerificationOptions, verifyDpopJwt } from '../dpop/dpop'
 import { Oauth2Error } from '../error/Oauth2Error'
 import { Oauth2ServerErrorResponseError } from '../error/Oauth2ServerErrorResponseError'
 import type { AuthorizationServerMetadata } from '../metadata/authorization-server/z-authorization-server-metadata'
@@ -26,7 +26,7 @@ import type {
 } from './parse-access-token-request'
 import type { AccessTokenRequest } from './z-access-token'
 
-export interface VerifyAccessTokenRequestDpop {
+export interface VerifyAccessTokenRequestDpop extends DpopVerificationOptions {
   /**
    * Whether dpop is required
    */
@@ -44,13 +44,6 @@ export interface VerifyAccessTokenRequestDpop {
   expectedJwkThumbprint?: string
 
   /**
-   * Allowed dpop signing alg values. If not provided
-   * any alg values are allowed and it's up to the `verifyJwtCallback`
-   * to handle the alg.
-   */
-  allowedSigningAlgs?: string[]
-
-  /**
    * Expected nonce in the dpop proof. If not provided the nonce won't be validated.
    *
    * For the DPoP-bound `attest_jwt_client_auth_dpop` method (draft 09) the server-provided client
@@ -58,23 +51,6 @@ export interface VerifyAccessTokenRequestDpop {
    * challenge to enforce it.
    */
   expectedNonce?: string
-
-  /**
-   * Maximum accepted age in seconds for the DPoP proof based on the `iat` claim.
-   */
-  maxProofAgeSeconds?: number
-
-  /**
-   * Allowed clock skew in seconds used when validating DPoP `iat` freshness.
-   *
-   * @default 0
-   */
-  allowedClockSkewSeconds?: number
-
-  /**
-   * Optional callback to enforce one-time use of DPoP `jti` values.
-   */
-  assertJtiUniqueness?: DpopAssertJtiUniquenessCallback
 }
 
 export interface VerifyAccessTokenRequestClientAttestation {

--- a/packages/oauth2/src/access-token/verify-access-token-request.ts
+++ b/packages/oauth2/src/access-token/verify-access-token-request.ts
@@ -14,7 +14,7 @@ import { calculateJwkThumbprint } from '../common/jwk/jwk-thumbprint'
 import type { Jwk } from '../common/jwk/z-jwk'
 import type { RequestLike } from '../common/z-common'
 import { Oauth2ErrorCodes } from '../common/z-oauth2-error'
-import { verifyDpopJwt } from '../dpop/dpop'
+import { type DpopAssertJtiUniquenessCallback, verifyDpopJwt } from '../dpop/dpop'
 import { Oauth2Error } from '../error/Oauth2Error'
 import { Oauth2ServerErrorResponseError } from '../error/Oauth2ServerErrorResponseError'
 import type { AuthorizationServerMetadata } from '../metadata/authorization-server/z-authorization-server-metadata'
@@ -58,6 +58,23 @@ export interface VerifyAccessTokenRequestDpop {
    * challenge to enforce it.
    */
   expectedNonce?: string
+
+  /**
+   * Maximum accepted age in seconds for the DPoP proof based on the `iat` claim.
+   */
+  maxProofAgeSeconds?: number
+
+  /**
+   * Allowed clock skew in seconds used when validating DPoP `iat` freshness.
+   *
+   * @default 0
+   */
+  allowedClockSkewSeconds?: number
+
+  /**
+   * Optional callback to enforce one-time use of DPoP `jti` values.
+   */
+  assertJtiUniqueness?: DpopAssertJtiUniquenessCallback
 }
 
 export interface VerifyAccessTokenRequestClientAttestation {
@@ -505,6 +522,9 @@ async function verifyAccessTokenRequestDpop(
     allowedSigningAlgs: options.allowedSigningAlgs,
     expectedJwkThumbprint: options.expectedJwkThumbprint,
     expectedNonce: options.expectedNonce,
+    maxProofAgeSeconds: options.maxProofAgeSeconds,
+    allowedClockSkewSeconds: options.allowedClockSkewSeconds,
+    assertJtiUniqueness: options.assertJtiUniqueness,
   })
 
   return {

--- a/packages/oauth2/src/authorization-request/verify-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/verify-authorization-request.ts
@@ -9,7 +9,7 @@ import { calculateJwkThumbprint } from '../common/jwk/jwk-thumbprint'
 import type { Jwk } from '../common/jwk/z-jwk'
 import type { RequestLike } from '../common/z-common'
 import { Oauth2ErrorCodes } from '../common/z-oauth2-error'
-import { verifyDpopJwt } from '../dpop/dpop'
+import { type DpopAssertJtiUniquenessCallback, verifyDpopJwt } from '../dpop/dpop'
 import { Oauth2ServerErrorResponseError } from '../error/Oauth2ServerErrorResponseError'
 import type { AuthorizationServerMetadata } from '../metadata/authorization-server/z-authorization-server-metadata'
 
@@ -41,6 +41,23 @@ export interface VerifyAuthorizationRequestDpop {
    * to handle the alg.
    */
   allowedSigningAlgs?: string[]
+
+  /**
+   * Maximum accepted age in seconds for the DPoP proof based on the `iat` claim.
+   */
+  maxProofAgeSeconds?: number
+
+  /**
+   * Allowed clock skew in seconds used when validating DPoP `iat` freshness.
+   *
+   * @default 0
+   */
+  allowedClockSkewSeconds?: number
+
+  /**
+   * Optional callback to enforce one-time use of DPoP `jti` values.
+   */
+  assertJtiUniqueness?: DpopAssertJtiUniquenessCallback
 }
 
 export interface VerifyAuthorizationRequestClientAttestation {
@@ -219,6 +236,9 @@ async function verifyAuthorizationRequestDpop(
         dpopJwt: options.jwt,
         request,
         allowedSigningAlgs: options.allowedSigningAlgs,
+        maxProofAgeSeconds: options.maxProofAgeSeconds,
+        allowedClockSkewSeconds: options.allowedClockSkewSeconds,
+        assertJtiUniqueness: options.assertJtiUniqueness,
         now,
       })
     : undefined

--- a/packages/oauth2/src/authorization-request/verify-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/verify-authorization-request.ts
@@ -9,11 +9,11 @@ import { calculateJwkThumbprint } from '../common/jwk/jwk-thumbprint'
 import type { Jwk } from '../common/jwk/z-jwk'
 import type { RequestLike } from '../common/z-common'
 import { Oauth2ErrorCodes } from '../common/z-oauth2-error'
-import { type DpopAssertJtiUniquenessCallback, verifyDpopJwt } from '../dpop/dpop'
+import { type DpopVerificationOptions, verifyDpopJwt } from '../dpop/dpop'
 import { Oauth2ServerErrorResponseError } from '../error/Oauth2ServerErrorResponseError'
 import type { AuthorizationServerMetadata } from '../metadata/authorization-server/z-authorization-server-metadata'
 
-export interface VerifyAuthorizationRequestDpop {
+export interface VerifyAuthorizationRequestDpop extends DpopVerificationOptions {
   /**
    * Whether dpop is required.
    */
@@ -34,30 +34,6 @@ export interface VerifyAuthorizationRequestDpop {
    * be provided. If both are provided, the jwk thumbprints are matched
    */
   jwkThumbprint?: string
-
-  /**
-   * Allowed dpop signing alg values. If not provided
-   * any alg values are allowed and it's up to the `verifyJwtCallback`
-   * to handle the alg.
-   */
-  allowedSigningAlgs?: string[]
-
-  /**
-   * Maximum accepted age in seconds for the DPoP proof based on the `iat` claim.
-   */
-  maxProofAgeSeconds?: number
-
-  /**
-   * Allowed clock skew in seconds used when validating DPoP `iat` freshness.
-   *
-   * @default 0
-   */
-  allowedClockSkewSeconds?: number
-
-  /**
-   * Optional callback to enforce one-time use of DPoP `jti` values.
-   */
-  assertJtiUniqueness?: DpopAssertJtiUniquenessCallback
 }
 
 export interface VerifyAuthorizationRequestClientAttestation {

--- a/packages/oauth2/src/dpop/__tests__/verify-dpop-jwt.test.mts
+++ b/packages/oauth2/src/dpop/__tests__/verify-dpop-jwt.test.mts
@@ -1,0 +1,285 @@
+import { describe, expect, test } from 'vitest'
+import { callbacks, getSignJwtCallback } from '../../../tests/util.mjs'
+import { HashAlgorithm } from '../../callbacks'
+import { calculateJwkThumbprint } from '../../common/jwk/jwk-thumbprint'
+import type { Jwk } from '../../common/jwk/z-jwk'
+import { createDpopJwt, verifyDpopJwt } from '../dpop'
+
+const request = {
+  method: 'POST',
+  url: 'https://authorization-server.com/token',
+  headers: new Headers(),
+} as const
+
+const dpopSignerJwk = {
+  kty: 'EC',
+  d: 'UxBOEoXuH9qlZ0Bo2E1sCuZDkAzVl99eenarvWMrgH0',
+  crv: 'P-256',
+  x: 'BvowcNvKitnPOIU7EQSP6mvHG46mqJp1iVEeaHRkzMQ',
+  y: 'h2kx9opNMxfK1_mcx2t5SIPf-kg4oNXS77tBxDvy1TM',
+} satisfies Jwk
+
+const otherSignerJwk = {
+  kty: 'EC',
+  d: '6xn3gj1pQisseLDhd1qtGbBr9oWBwxxvAMBSDerbSzk',
+  crv: 'P-256',
+  x: 'CQHN_Jmxy4yDZzDmudBArRip9DtU8bpNDdtya7yj6f4',
+  y: 'sDsPt93iLO7eZdt0-qVwD3bRAaG1V_3wmYdw3dr_lfs',
+} satisfies Jwk
+
+const { d: _, ...dpopSignerPublicJwk } = dpopSignerJwk
+const { d: __, ...otherSignerPublicJwk } = otherSignerJwk
+
+describe('verifyDpopJwt', () => {
+  test('verifies a valid proof with matching expected jwk thumbprint', async () => {
+    const dpopJwt = await createDpopJwt({
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([dpopSignerJwk]),
+      },
+      request,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: dpopSignerPublicJwk,
+      },
+    })
+
+    const expectedJwkThumbprint = await calculateJwkThumbprint({
+      hashAlgorithm: HashAlgorithm.Sha256,
+      hashCallback: callbacks.hash,
+      jwk: dpopSignerPublicJwk,
+    })
+
+    const result = await verifyDpopJwt({
+      callbacks,
+      dpopJwt,
+      request,
+      expectedJwkThumbprint,
+      allowedSigningAlgs: ['ES256'],
+    })
+
+    expect(result.jwkThumbprint).toBe(expectedJwkThumbprint)
+  })
+
+  test('rejects proofs signed by the wrong key', async () => {
+    const dpopJwt = await createDpopJwt({
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([dpopSignerJwk]),
+      },
+      request,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: dpopSignerPublicJwk,
+      },
+    })
+
+    const expectedJwkThumbprint = await calculateJwkThumbprint({
+      hashAlgorithm: HashAlgorithm.Sha256,
+      hashCallback: callbacks.hash,
+      jwk: otherSignerPublicJwk,
+    })
+
+    await expect(
+      verifyDpopJwt({
+        callbacks,
+        dpopJwt,
+        request,
+        expectedJwkThumbprint,
+      })
+    ).rejects.toThrow("expect jwk thumbprint value")
+  })
+
+  test('rejects proofs with wrong HTTP method', async () => {
+    const dpopJwt = await createDpopJwt({
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([dpopSignerJwk]),
+      },
+      request,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: dpopSignerPublicJwk,
+      },
+    })
+
+    await expect(
+      verifyDpopJwt({
+        callbacks,
+        dpopJwt,
+        request: {
+          ...request,
+          method: 'GET',
+        },
+      })
+    ).rejects.toThrow("expected htm value 'GET'")
+  })
+
+  test('rejects proofs with wrong URL', async () => {
+    const dpopJwt = await createDpopJwt({
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([dpopSignerJwk]),
+      },
+      request,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: dpopSignerPublicJwk,
+      },
+    })
+
+    await expect(
+      verifyDpopJwt({
+        callbacks,
+        dpopJwt,
+        request: {
+          ...request,
+          url: 'https://authorization-server.com/another-endpoint',
+        },
+      })
+    ).rejects.toThrow("expected htu value 'https://authorization-server.com/another-endpoint'")
+  })
+
+  test('rejects stale proofs when maxProofAgeSeconds is exceeded', async () => {
+    const dpopJwt = await createDpopJwt({
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([dpopSignerJwk]),
+      },
+      request,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: dpopSignerPublicJwk,
+      },
+      issuedAt: new Date('2024-01-01T00:00:00.000Z'),
+    })
+
+    await expect(
+      verifyDpopJwt({
+        callbacks,
+        dpopJwt,
+        request,
+        now: new Date('2024-01-01T00:02:00.000Z'),
+        maxProofAgeSeconds: 30,
+      })
+    ).rejects.toThrow('Dpop jwt is too old')
+  })
+
+  test('rejects replayed jti values when uniqueness callback indicates replay', async () => {
+    const dpopJwt = await createDpopJwt({
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([dpopSignerJwk]),
+      },
+      request,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: dpopSignerPublicJwk,
+      },
+    })
+
+    const seenJti = new Set<string>()
+    const assertJtiUniqueness = ({ jti }: { jti: string }) => {
+      if (seenJti.has(jti)) return false
+      seenJti.add(jti)
+      return true
+    }
+
+    await expect(
+      verifyDpopJwt({
+        callbacks,
+        dpopJwt,
+        request,
+        assertJtiUniqueness,
+      })
+    ).resolves.toBeDefined()
+
+    await expect(
+      verifyDpopJwt({
+        callbacks,
+        dpopJwt,
+        request,
+        assertJtiUniqueness,
+      })
+    ).rejects.toThrow('already been used')
+  })
+
+  test('rejects missing nonce when nonce is expected', async () => {
+    const dpopJwt = await createDpopJwt({
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([dpopSignerJwk]),
+      },
+      request,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: dpopSignerPublicJwk,
+      },
+    })
+
+    await expect(
+      verifyDpopJwt({
+        callbacks,
+        dpopJwt,
+        request,
+        expectedNonce: 'nonce-1',
+      })
+    ).rejects.toThrow('does not have a nonce value')
+  })
+
+  test('rejects invalid nonce values', async () => {
+    const dpopJwt = await createDpopJwt({
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([dpopSignerJwk]),
+      },
+      request,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: dpopSignerPublicJwk,
+      },
+      nonce: 'actual-nonce',
+    })
+
+    await expect(
+      verifyDpopJwt({
+        callbacks,
+        dpopJwt,
+        request,
+        expectedNonce: 'different-nonce',
+      })
+    ).rejects.toThrow('but expected nonce value')
+  })
+
+  test('rejects unsupported proof algorithms', async () => {
+    const dpopJwt = await createDpopJwt({
+      callbacks: {
+        ...callbacks,
+        signJwt: getSignJwtCallback([dpopSignerJwk]),
+      },
+      request,
+      signer: {
+        method: 'jwk',
+        alg: 'ES256',
+        publicJwk: dpopSignerPublicJwk,
+      },
+    })
+
+    await expect(
+      verifyDpopJwt({
+        callbacks,
+        dpopJwt,
+        request,
+        allowedSigningAlgs: ['ES384'],
+      })
+    ).rejects.toThrow('allowed dpop signging alg values are ES384')
+  })
+})

--- a/packages/oauth2/src/dpop/__tests__/verify-dpop-jwt.test.mts
+++ b/packages/oauth2/src/dpop/__tests__/verify-dpop-jwt.test.mts
@@ -185,9 +185,20 @@ describe('verifyDpopJwt', () => {
     })
 
     const seenJti = new Set<string>()
-    const assertJtiUniqueness = ({ jti }: { jti: string }) => {
-      if (seenJti.has(jti)) return false
-      seenJti.add(jti)
+    const assertJtiUniqueness = ({
+      header,
+      payload,
+      compact,
+    }: {
+      header: { typ: string }
+      payload: { jti: string }
+      compact: string
+    }) => {
+      expect(header.typ).toBe('dpop+jwt')
+      expect(compact).toBe(dpopJwt)
+
+      if (seenJti.has(payload.jti)) return false
+      seenJti.add(payload.jti)
       return true
     }
 

--- a/packages/oauth2/src/dpop/__tests__/verify-dpop-jwt.test.mts
+++ b/packages/oauth2/src/dpop/__tests__/verify-dpop-jwt.test.mts
@@ -89,7 +89,7 @@ describe('verifyDpopJwt', () => {
         request,
         expectedJwkThumbprint,
       })
-    ).rejects.toThrow("expect jwk thumbprint value")
+    ).rejects.toThrow('expect jwk thumbprint value')
   })
 
   test('rejects proofs with wrong HTTP method', async () => {

--- a/packages/oauth2/src/dpop/dpop.ts
+++ b/packages/oauth2/src/dpop/dpop.ts
@@ -3,6 +3,7 @@ import {
   decodeUtf8String,
   encodeToBase64Url,
   type FetchHeaders,
+  type OrPromise,
   parseWithErrorHandling,
   URL,
 } from '@openid4vc/utils'
@@ -113,7 +114,7 @@ export interface VerifyDpopJwtOptions {
   dpopJwt: string
 
   /**
-   * The requet for which to verify the dpop jwt
+   * The request for which to verify the dpop jwt
    */
   request: RequestLike
 
@@ -144,12 +145,45 @@ export interface VerifyDpopJwtOptions {
   expectedJwkThumbprint?: string
 
   /**
+   * Maximum accepted age in seconds for the DPoP proof based on the `iat` claim.
+   *
+   * If provided, the proof is rejected when it is older than this value.
+   */
+  maxProofAgeSeconds?: number
+
+  /**
+   * Allowed clock skew in seconds used when validating freshness based on `iat`.
+   *
+   * @default 0
+   */
+  allowedClockSkewSeconds?: number
+
+  /**
+   * Callback to enforce one-time usage of the DPoP proof `jti`.
+   *
+   * Return `true` to accept the proof as not replayed, `false` to reject as replayed.
+   */
+  assertJtiUniqueness?: DpopAssertJtiUniquenessCallback
+
+  /**
    * Callbacks used for verifying dpop jwt
    */
   callbacks: Pick<CallbackContext, 'verifyJwt' | 'hash'>
 
   now?: Date
 }
+
+export interface DpopAssertJtiUniquenessOptions {
+  jti: string
+  iat: number
+  htm: string
+  htu: string
+  jwkThumbprint: string
+  dpopJwt: string
+  now: Date
+}
+
+export type DpopAssertJtiUniquenessCallback = (options: DpopAssertJtiUniquenessOptions) => OrPromise<boolean>
 
 export async function verifyDpopJwt(options: VerifyDpopJwtOptions) {
   try {
@@ -190,6 +224,29 @@ export async function verifyDpopJwt(options: VerifyDpopJwtOptions) {
       throw new Oauth2Error(`Dpop jwt contains htu value '${payload.htu}', but expected htu value '${expectedHtu}'.`)
     }
 
+    const now = options.now ?? new Date()
+    if (options.maxProofAgeSeconds !== undefined) {
+      if (options.maxProofAgeSeconds < 0) {
+        throw new Oauth2Error(`maxProofAgeSeconds must be greater than or equal to 0, received '${options.maxProofAgeSeconds}'.`)
+      }
+
+      const nowInSeconds = dateToSeconds(now)
+      const allowedSkew = options.allowedClockSkewSeconds ?? 0
+      const proofAgeInSeconds = nowInSeconds - payload.iat
+
+      if (payload.iat > nowInSeconds + allowedSkew) {
+        throw new Oauth2Error(
+          `Dpop jwt contains iat value '${payload.iat}' that is in the future relative to now '${nowInSeconds}' with allowed skew '${allowedSkew}'.`
+        )
+      }
+
+      if (proofAgeInSeconds > options.maxProofAgeSeconds + allowedSkew) {
+        throw new Oauth2Error(
+          `Dpop jwt is too old. Proof age is '${proofAgeInSeconds}' seconds, but max allowed age is '${options.maxProofAgeSeconds}' seconds with allowed skew '${allowedSkew}'.`
+        )
+      }
+    }
+
     if (options.accessToken) {
       const expectedAth = encodeToBase64Url(
         await options.callbacks.hash(decodeUtf8String(options.accessToken), HashAlgorithm.Sha256)
@@ -214,6 +271,22 @@ export async function verifyDpopJwt(options: VerifyDpopJwtOptions) {
       throw new Oauth2Error(
         `Dpop is signed with jwk with thumbprint value '${jwkThumbprint}', but expect jwk thumbprint value '${options.expectedJwkThumbprint}'`
       )
+    }
+
+    if (options.assertJtiUniqueness) {
+      const isUnique = await options.assertJtiUniqueness({
+        jti: payload.jti,
+        iat: payload.iat,
+        htm: payload.htm,
+        htu: payload.htu,
+        jwkThumbprint,
+        dpopJwt: options.dpopJwt,
+        now,
+      })
+
+      if (!isUnique) {
+        throw new Oauth2Error(`Dpop jwt with jti value '${payload.jti}' has already been used.`)
+      }
     }
 
     await verifyJwt({

--- a/packages/oauth2/src/dpop/dpop.ts
+++ b/packages/oauth2/src/dpop/dpop.ts
@@ -107,42 +107,13 @@ export async function createDpopJwt(options: CreateDpopJwtOptions) {
   return jwt
 }
 
-export interface VerifyDpopJwtOptions {
-  /**
-   * The compact dpop jwt.
-   */
-  dpopJwt: string
-
-  /**
-   * The request for which to verify the dpop jwt
-   */
-  request: RequestLike
-
+export interface DpopVerificationOptions {
   /**
    * Allowed dpop signing alg values. If not provided
    * any alg values are allowed and it's up to the `verifyJwtCallback`
    * to handle the alg.
    */
   allowedSigningAlgs?: string[]
-
-  /**
-   * Expected nonce in the payload. If not provided the nonce won't be validated.
-   */
-  expectedNonce?: string
-
-  /**
-   * Access token to which the dpop jwt is bound. If provided the sha-256 hash of the
-   * access token needs to match the 'ath' claim.
-   */
-  accessToken?: string
-
-  /**
-   * The expected jwk thumprint 'jti' confirmation method. If provided the thumprint of the
-   * jwk used to sign the dpop jwt must match this provided thumbprint value. The 'jti' value
-   * can be extracted from the access token payload, or if opaque tokens are used can be retrieved
-   * using token introspection.
-   */
-  expectedJwkThumbprint?: string
 
   /**
    * Maximum accepted age in seconds for the DPoP proof based on the `iat` claim.
@@ -164,6 +135,37 @@ export interface VerifyDpopJwtOptions {
    * Return `true` to accept the proof as not replayed, `false` to reject as replayed.
    */
   assertJtiUniqueness?: DpopAssertJtiUniquenessCallback
+}
+
+export interface VerifyDpopJwtOptions extends DpopVerificationOptions {
+  /**
+   * The compact dpop jwt.
+   */
+  dpopJwt: string
+
+  /**
+   * The request for which to verify the dpop jwt
+   */
+  request: RequestLike
+
+  /**
+   * Expected nonce in the payload. If not provided the nonce won't be validated.
+   */
+  expectedNonce?: string
+
+  /**
+   * Access token to which the dpop jwt is bound. If provided the sha-256 hash of the
+   * access token needs to match the 'ath' claim.
+   */
+  accessToken?: string
+
+  /**
+   * The expected jwk thumprint 'jti' confirmation method. If provided the thumprint of the
+   * jwk used to sign the dpop jwt must match this provided thumbprint value. The 'jti' value
+   * can be extracted from the access token payload, or if opaque tokens are used can be retrieved
+   * using token introspection.
+   */
+  expectedJwkThumbprint?: string
 
   /**
    * Callbacks used for verifying dpop jwt
@@ -227,7 +229,9 @@ export async function verifyDpopJwt(options: VerifyDpopJwtOptions) {
     const now = options.now ?? new Date()
     if (options.maxProofAgeSeconds !== undefined) {
       if (options.maxProofAgeSeconds < 0) {
-        throw new Oauth2Error(`maxProofAgeSeconds must be greater than or equal to 0, received '${options.maxProofAgeSeconds}'.`)
+        throw new Oauth2Error(
+          `maxProofAgeSeconds must be greater than or equal to 0, received '${options.maxProofAgeSeconds}'.`
+        )
       }
 
       const nowInSeconds = dateToSeconds(now)

--- a/packages/oauth2/src/dpop/dpop.ts
+++ b/packages/oauth2/src/dpop/dpop.ts
@@ -9,7 +9,7 @@ import {
 } from '@openid4vc/utils'
 import { type CallbackContext, HashAlgorithm } from '../callbacks'
 import { calculateJwkThumbprint } from '../common/jwk/jwk-thumbprint'
-import { decodeJwt } from '../common/jwt/decode-jwt'
+import { type DecodeJwtResult, decodeJwt } from '../common/jwt/decode-jwt'
 import { verifyJwt } from '../common/jwt/verify-jwt'
 import { type JwtSignerJwk, zCompactJwt } from '../common/jwt/z-jwt'
 import type { RequestLike } from '../common/z-common'
@@ -175,13 +175,8 @@ export interface VerifyDpopJwtOptions extends DpopVerificationOptions {
   now?: Date
 }
 
-export interface DpopAssertJtiUniquenessOptions {
-  jti: string
-  iat: number
-  htm: string
-  htu: string
+export interface DpopAssertJtiUniquenessOptions extends DecodeJwtResult<typeof zDpopJwtHeader, typeof zDpopJwtPayload> {
   jwkThumbprint: string
-  dpopJwt: string
   now: Date
 }
 
@@ -189,11 +184,12 @@ export type DpopAssertJtiUniquenessCallback = (options: DpopAssertJtiUniquenessO
 
 export async function verifyDpopJwt(options: VerifyDpopJwtOptions) {
   try {
-    const { header, payload } = decodeJwt({
+    const decodedDpopJwt = decodeJwt({
       jwt: options.dpopJwt,
       headerSchema: zDpopJwtHeader,
       payloadSchema: zDpopJwtPayload,
     })
+    const { header, payload } = decodedDpopJwt
 
     if (options.allowedSigningAlgs && !options.allowedSigningAlgs.includes(header.alg)) {
       throw new Oauth2Error(
@@ -279,12 +275,8 @@ export async function verifyDpopJwt(options: VerifyDpopJwtOptions) {
 
     if (options.assertJtiUniqueness) {
       const isUnique = await options.assertJtiUniqueness({
-        jti: payload.jti,
-        iat: payload.iat,
-        htm: payload.htm,
-        htu: payload.htu,
+        ...decodedDpopJwt,
         jwkThumbprint,
-        dpopJwt: options.dpopJwt,
         now,
       })
 

--- a/packages/oauth2/src/resource-request/verify-resource-request.ts
+++ b/packages/oauth2/src/resource-request/verify-resource-request.ts
@@ -7,34 +7,11 @@ import type { CallbackContext } from '../callbacks'
 import type { Jwk } from '../common/jwk/z-jwk'
 import type { RequestLike } from '../common/z-common'
 import { Oauth2ErrorCodes } from '../common/z-oauth2-error'
-import {
-  extractDpopJwtFromHeaders,
-  type DpopAssertJtiUniquenessCallback,
-  verifyDpopJwt,
-} from '../dpop/dpop'
+import { type DpopVerificationOptions, extractDpopJwtFromHeaders, verifyDpopJwt } from '../dpop/dpop'
 import { Oauth2Error } from '../error/Oauth2Error'
 import { Oauth2JwtParseError } from '../error/Oauth2JwtParseError'
 import { Oauth2ResourceUnauthorizedError } from '../error/Oauth2ResourceUnauthorizedError'
 import type { AuthorizationServerMetadata } from '../metadata/authorization-server/z-authorization-server-metadata'
-
-export interface VerifyResourceRequestDpopOptions {
-  /**
-   * Maximum accepted age in seconds for the DPoP proof based on the `iat` claim.
-   */
-  maxProofAgeSeconds?: number
-
-  /**
-   * Allowed clock skew in seconds used when validating DPoP `iat` freshness.
-   *
-   * @default 0
-   */
-  allowedClockSkewSeconds?: number
-
-  /**
-   * Optional callback to enforce one-time use of DPoP `jti` values.
-   */
-  assertJtiUniqueness?: DpopAssertJtiUniquenessCallback
-}
 
 export interface VerifyResourceRequestOptions {
   /**
@@ -66,7 +43,7 @@ export interface VerifyResourceRequestOptions {
   /**
    * Additional DPoP verification options.
    */
-  dpop?: VerifyResourceRequestDpopOptions
+  dpop?: DpopVerificationOptions
 
   now?: Date
 }

--- a/packages/oauth2/src/resource-request/verify-resource-request.ts
+++ b/packages/oauth2/src/resource-request/verify-resource-request.ts
@@ -7,11 +7,34 @@ import type { CallbackContext } from '../callbacks'
 import type { Jwk } from '../common/jwk/z-jwk'
 import type { RequestLike } from '../common/z-common'
 import { Oauth2ErrorCodes } from '../common/z-oauth2-error'
-import { extractDpopJwtFromHeaders, verifyDpopJwt } from '../dpop/dpop'
+import {
+  extractDpopJwtFromHeaders,
+  type DpopAssertJtiUniquenessCallback,
+  verifyDpopJwt,
+} from '../dpop/dpop'
 import { Oauth2Error } from '../error/Oauth2Error'
 import { Oauth2JwtParseError } from '../error/Oauth2JwtParseError'
 import { Oauth2ResourceUnauthorizedError } from '../error/Oauth2ResourceUnauthorizedError'
 import type { AuthorizationServerMetadata } from '../metadata/authorization-server/z-authorization-server-metadata'
+
+export interface VerifyResourceRequestDpopOptions {
+  /**
+   * Maximum accepted age in seconds for the DPoP proof based on the `iat` claim.
+   */
+  maxProofAgeSeconds?: number
+
+  /**
+   * Allowed clock skew in seconds used when validating DPoP `iat` freshness.
+   *
+   * @default 0
+   */
+  allowedClockSkewSeconds?: number
+
+  /**
+   * Optional callback to enforce one-time use of DPoP `jti` values.
+   */
+  assertJtiUniqueness?: DpopAssertJtiUniquenessCallback
+}
 
 export interface VerifyResourceRequestOptions {
   /**
@@ -39,6 +62,11 @@ export interface VerifyResourceRequestOptions {
    * List of authorization servers that this resource endpoint supports
    */
   authorizationServers: AuthorizationServerMetadata[]
+
+  /**
+   * Additional DPoP verification options.
+   */
+  dpop?: VerifyResourceRequestDpopOptions
 
   now?: Date
 }
@@ -181,6 +209,9 @@ export async function verifyResourceRequest(options: VerifyResourceRequestOption
         now: options.now,
         expectedJwkThumbprint: tokenPayload.cnf?.jkt,
         allowedSigningAlgs: authorizationServer.dpop_signing_alg_values_supported,
+        maxProofAgeSeconds: options.dpop?.maxProofAgeSeconds,
+        allowedClockSkewSeconds: options.dpop?.allowedClockSkewSeconds,
+        assertJtiUniqueness: options.dpop?.assertJtiUniqueness,
       })
       dpopJwk = decodedDpopJwt.header.jwk
     } catch (error) {


### PR DESCRIPTION
Align DPoP with OAuth 2.0 expectations around proof validation and anti-replay controls

* Use `iat` age checks for freshness + clock skew handling
* One-time proof usage via `jti` uniqueness checks (server-side replay defence hook)
* Validate core proof-binding semantics (`htm`, `htu`, key thumbprint)

Explicit negative tests for nonce mismatches, unsupported algorithms, method/URL mismatches, stale proofs and replayed proofs

Minor version bump because of API update (optional params)