### PR TITLE
fix: ignore legacy jarm parameters if v1 encryption is provided

### DIFF
--- a/.changeset/ignore-legacy-response-encryption.md
+++ b/.changeset/ignore-legacy-response-encryption.md
@@ -1,0 +1,5 @@
+---
+'@openid4vc/openid4vp': patch
+---
+
+Ignore the pre-draft-27 `authorization_encrypted_response_alg` and `authorization_encrypted_response_enc` client metadata parameters when the verifier also sends the 1.0 `encrypted_response_enc_values_supported`. Previously a verifier sending both generations of the response encryption metadata could fail with `Invalid authorization_encryption_enc`.

--- a/packages/openid4vp/src/authorization-response/__tests__/create-authorization-response-encryption.test.mts
+++ b/packages/openid4vp/src/authorization-response/__tests__/create-authorization-response-encryption.test.mts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'vitest'
+import { createOpenid4vpAuthorizationResponse } from '../create-authorization-response.js'
+
+const encJwk = {
+  kty: 'EC',
+  alg: 'ECDH-ES',
+  crv: 'P-256',
+  x: 'PHVtfGzwfShN50aP1Vqw9PW2y1Hwe_lvprL2Ev-Kzbg',
+  y: 'qCj6yA31O3Sr6FCOGb1SO5XdpfVySG1uk5cMr6zmq9c',
+  kid: '5DFw7cUedUNDAjmqUpZFVE66Tx45rg2sRfp3YV4ykLtF',
+  use: 'enc',
+} as const
+
+// Mirrors what the Credo holder advertises
+const serverMetadata = {
+  authorization_signing_alg_values_supported: [],
+  authorization_encryption_alg_values_supported: ['ECDH-ES'],
+  authorization_encryption_enc_values_supported: ['A128GCM', 'A256GCM', 'A128CBC-HS256'],
+}
+
+async function createResponse(clientMetadata: Record<string, unknown>) {
+  let encryptor: { alg: string; enc: string } | undefined
+
+  await createOpenid4vpAuthorizationResponse({
+    // biome-ignore lint/suspicious/noExplicitAny: test fixture
+    authorizationRequestPayload: {
+      response_type: 'vp_token',
+      response_mode: 'dc_api.jwt',
+      client_id: 'x509_hash:vNyA8UYcjZBBewa_AMzAV3Bs3B1Ql9yH01xQhQVXN7o',
+      nonce: 'HVI5aa23NzijX-AMlQ3jDJMMCx8nkdlSdnji44Zq1-c',
+      expected_origins: ['https://verify.trinsic.id'],
+      client_metadata: { jwks: { keys: [encJwk] }, ...clientMetadata },
+    } as any,
+    origin: 'https://verify.trinsic.id',
+    authorizationResponsePayload: { vp_token: { cred: ['abc'] } },
+    jarm: { encryption: { nonce: 'response-nonce' }, serverMetadata },
+    callbacks: {
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture
+      encryptJwe: (jweEncryptor: any) => {
+        encryptor = { alg: jweEncryptor.alg, enc: jweEncryptor.enc }
+        return { encryptionJwk: encJwk, jwe: 'jwe' }
+      },
+      signJwt: () => {
+        throw new Error('Not implemented')
+      },
+      fetch,
+      getJwks: () => {
+        throw new Error('Not implemented')
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture
+    } as any,
+  })
+
+  return encryptor
+}
+
+describe('createOpenid4vpAuthorizationResponse response encryption metadata', () => {
+  test('ignores a leftover legacy alg when the 1.0 enc values are present', async () => {
+    // Shape sent by the Trinsic verifier: a 1.0 request that still carries the pre-27
+    // `authorization_encrypted_response_alg`, but no longer the matching `_enc`.
+    await expect(
+      createResponse({
+        authorization_encrypted_response_alg: 'ECDH-ES',
+        encrypted_response_enc_values_supported: ['A128GCM', 'A256GCM'],
+      })
+    ).resolves.toEqual({ alg: 'ECDH-ES', enc: 'A128GCM' })
+  })
+
+  test('ignores legacy enc we do not support when the 1.0 enc values are present', async () => {
+    await expect(
+      createResponse({
+        authorization_encrypted_response_alg: 'ECDH-ES',
+        authorization_encrypted_response_enc: 'A192GCM',
+        encrypted_response_enc_values_supported: ['A256GCM'],
+      })
+    ).resolves.toEqual({ alg: 'ECDH-ES', enc: 'A256GCM' })
+  })
+
+  test('still validates legacy metadata when the 1.0 enc values are absent', async () => {
+    await expect(
+      createResponse({
+        authorization_encrypted_response_alg: 'ECDH-ES',
+        authorization_encrypted_response_enc: 'A192GCM',
+      })
+    ).rejects.toThrow('Invalid authorization_encryption_enc')
+  })
+
+  test('defaults enc when a pre-27 verifier only sends the legacy alg', async () => {
+    await expect(createResponse({ authorization_encrypted_response_alg: 'ECDH-ES' })).resolves.toEqual({
+      alg: 'ECDH-ES',
+      enc: 'A128GCM',
+    })
+  })
+})

--- a/packages/openid4vp/src/authorization-response/create-authorization-response.ts
+++ b/packages/openid4vp/src/authorization-response/create-authorization-response.ts
@@ -125,13 +125,25 @@ export async function createOpenid4vpAuthorizationResponse(
     })
   }
 
-  if (
-    clientMetadata.authorization_encrypted_response_alg ||
-    clientMetadata.authorization_encrypted_response_enc ||
-    clientMetadata.authorization_signed_response_alg
-  ) {
+  // From draft 28 the JARM response encryption parameters were replaced by
+  // `encrypted_response_enc_values_supported`, with the `alg` derived from the encryption JWK.
+  // Verifiers migrating between versions have been seen to send both generations at once, so when
+  // the 1.0 parameter is present it takes precedence and the legacy encryption parameters are ignored.
+  const useLegacyEncryptionMetadata = clientMetadata.encrypted_response_enc_values_supported === undefined
+  const legacyEncryptedResponseAlg = useLegacyEncryptionMetadata
+    ? clientMetadata.authorization_encrypted_response_alg
+    : undefined
+  const legacyEncryptedResponseEnc = useLegacyEncryptionMetadata
+    ? clientMetadata.authorization_encrypted_response_enc
+    : undefined
+
+  if (legacyEncryptedResponseAlg || legacyEncryptedResponseEnc || clientMetadata.authorization_signed_response_alg) {
     jarmAssertMetadataSupported({
-      clientMetadata: clientMetadata,
+      clientMetadata: {
+        ...clientMetadata,
+        authorization_encrypted_response_alg: legacyEncryptedResponseAlg,
+        authorization_encrypted_response_enc: legacyEncryptedResponseEnc,
+      },
       serverMetadata: jarm.serverMetadata,
     })
   }
@@ -142,9 +154,7 @@ export async function createOpenid4vpAuthorizationResponse(
     extractEncryptionJwkFromJwks(jwks, {
       supportedAlgValues:
         jarm.serverMetadata.authorization_encryption_alg_values_supported ??
-        (clientMetadata.authorization_encrypted_response_alg
-          ? [clientMetadata.authorization_encrypted_response_alg]
-          : undefined),
+        (legacyEncryptedResponseAlg ? [legacyEncryptedResponseAlg] : undefined),
     })
 
   if (!encJwk) {
@@ -164,7 +174,7 @@ export async function createOpenid4vpAuthorizationResponse(
       ) ?? clientMetadata.encrypted_response_enc_values_supported[0]
   } else {
     // Use old value, or otherwise fallback to default
-    enc = clientMetadata.authorization_encrypted_response_enc ?? 'A128GCM'
+    enc = legacyEncryptedResponseEnc ?? 'A128GCM'
   }
 
   assertValueSupported({
@@ -173,7 +183,7 @@ export async function createOpenid4vpAuthorizationResponse(
     errorMessage: `Invalid 'enc' value ${enc}. Supported values are ${jarm.serverMetadata.authorization_encryption_enc_values_supported.join(', ')}`,
   })
 
-  const alg = encJwk.alg ?? clientMetadata.authorization_encrypted_response_alg ?? 'ECDH-ES'
+  const alg = encJwk.alg ?? legacyEncryptedResponseAlg ?? 'ECDH-ES'
   assertValueSupported({
     actual: alg,
     supported: jarm.serverMetadata.authorization_encryption_alg_values_supported,

--- a/packages/openid4vp/src/jarm/metadata/__tests__/jarm-assert-metadata-supported.test.mts
+++ b/packages/openid4vp/src/jarm/metadata/__tests__/jarm-assert-metadata-supported.test.mts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest'
+import { jarmAssertMetadataSupported } from '../jarm-assert-metadata-supported.js'
+
+const serverMetadata = {
+  authorization_signing_alg_values_supported: [],
+  authorization_encryption_alg_values_supported: ['ECDH-ES'],
+  authorization_encryption_enc_values_supported: ['A128GCM', 'A256GCM', 'A128CBC-HS256'],
+}
+
+describe('jarmAssertMetadataSupported', () => {
+  test('does not assert enc when client metadata omits authorization_encrypted_response_enc', () => {
+    // Verifiers may combine the pre-27 `authorization_encrypted_response_alg` with the draft 28
+    // `encrypted_response_enc_values_supported`, leaving the legacy `enc` param out entirely.
+    expect(
+      jarmAssertMetadataSupported({
+        clientMetadata: { authorization_encrypted_response_alg: 'ECDH-ES' },
+        serverMetadata,
+      })
+    ).toEqual({
+      type: 'encrypt',
+      client_metadata: { authorization_encrypted_response_alg: 'ECDH-ES' },
+    })
+  })
+
+  test('asserts enc when client metadata includes authorization_encrypted_response_enc', () => {
+    expect(() =>
+      jarmAssertMetadataSupported({
+        clientMetadata: {
+          authorization_encrypted_response_alg: 'ECDH-ES',
+          authorization_encrypted_response_enc: 'A192GCM',
+        },
+        serverMetadata,
+      })
+    ).toThrow('Invalid authorization_encryption_enc')
+  })
+})

--- a/packages/openid4vp/src/jarm/metadata/jarm-assert-metadata-supported.ts
+++ b/packages/openid4vp/src/jarm/metadata/jarm-assert-metadata-supported.ts
@@ -35,7 +35,13 @@ export function jarmAssertMetadataSupported(options: {
       })
     }
 
-    if (serverMetadata.authorization_encryption_enc_values_supported) {
+    // `authorization_encrypted_response_enc` is optional. Clients can omit it (and e.g. use the
+    // newer `encrypted_response_enc_values_supported` instead), in which case the `enc` value is
+    // negotiated separately and there's nothing to assert here.
+    if (
+      serverMetadata.authorization_encryption_enc_values_supported &&
+      parsedClientMetadata.client_metadata.authorization_encrypted_response_enc
+    ) {
       assertValueSupported({
         supported: serverMetadata.authorization_encryption_enc_values_supported,
         actual: parsedClientMetadata.client_metadata.authorization_encrypted_response_enc,


### PR DESCRIPTION
Noticed some verifiers were passing both v1 and legacy encryption params. This ensures we don't trip on that